### PR TITLE
Add workflow for commenting released PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,9 @@
 name: CI/CD
 
-on:
-  release:
-    types:
-      - published
+# on:
+#   release:
+#     types:
+#       - published
 
 env:
   ARTIFACT_NAME: ${{ 'minesweeper-compiled' }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,14 +1,9 @@
 name: CI/CD
 
-# on:
-#   release:
-#     types:
-#       - published
-
 on:
-  push:
-    branches-ignore:
-      - '**'
+  release:
+    types:
+      - published
 
 env:
   ARTIFACT_NAME: ${{ 'minesweeper-compiled' }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,11 @@ name: CI/CD
 #     types:
 #       - published
 
+on:
+  push:
+    branches-ignore:
+      - '**'
+
 env:
   ARTIFACT_NAME: ${{ 'minesweeper-compiled' }}
   ARTIFACT_PATH: ${{ 'artifact' }}

--- a/.github/workflows/commentReleasedPRs.yml
+++ b/.github/workflows/commentReleasedPRs.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: rdlf0/comment-released-prs-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commentReleasedPRs.yml
+++ b/.github/workflows/commentReleasedPRs.yml
@@ -1,4 +1,4 @@
-name: Comment Released PRs
+name: Comment released PRs
 
 on:
   release:
@@ -7,9 +7,10 @@ on:
 
 jobs:
   comment:
-    name: Comment
+    name: Comment released PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: rdlf0/comment-released-prs-action@v1
+      - name: Comment released PRs
+        uses: rdlf0/comment-released-prs-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commentReleasedPRs.yml
+++ b/.github/workflows/commentReleasedPRs.yml
@@ -1,0 +1,15 @@
+name: Comment Released PRs
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  comment:
+    name: Comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rdlf0/comment-released-prs-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A new workflow triggered on `release:published` is added that calls the `rdlf0/comment-released-prs-action` action.