### PR TITLE
Scheduled dark mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,12 +1,22 @@
 /**
  * Night mode toggle
  */
-document.getElementById("dark-mode-toggle").addEventListener("click", toggleNightMode);
+const darkModeToggle = document.getElementById("dark-mode-toggle");
+darkModeToggle.addEventListener("click", toggleNightMode);
 
 function toggleNightMode(e) {
     e.preventDefault();
     const state = document.body.classList.toggle('night') ? "OFF" : "ON";
     e.target.childNodes[1].textContent = state;
+}
+
+// A temporary solution
+const date = new Date();
+const currentHour = date.getHours();
+const nigthModeStartHour = 21;
+const nigthModeEndHour = 7;
+if (currentHour >= nigthModeStartHour || currentHour <= nigthModeEndHour) {
+    darkModeToggle.click();
 }
 
 /**


### PR DESCRIPTION
This PR adds a simple scheduling for enabling the dark mode with hardcoded hours (start at 21:00, end at 7:00). This should be reworked at some point probably when #2 gets done. The switch should be transformed into a separate component so that it will have access to the config from which it will be able to get the start/end hour values.