### PR TITLE
Optimized board state use

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -39,11 +39,11 @@ export class Board {
     }
 
     private subscribe(): void {
-        this.eventSubscribers.forEach((p: EventSubscriber) => PubSub.subscribe(p.event, p.subscriber))
+        this.eventSubscribers.forEach((es: EventSubscriber) => PubSub.subscribe(es.event, es.subscriber))
     }
 
     public unsubscribe(): void {
-        this.eventSubscribers.forEach((p: EventSubscriber) => PubSub.unsubscribe(p.event, p.subscriber))
+        this.eventSubscribers.forEach((es: EventSubscriber) => PubSub.unsubscribe(es.event, es.subscriber))
     }
 
     public getMode(): Mode {
@@ -143,12 +143,12 @@ export class Board {
         return Math.floor(Math.random() * to) + from;
     }
 
-    public draw(board: HTMLElement): void {
+    public draw(boardEl: HTMLElement): void {
         // Remove existing cells (on reset/replay)
-        board.textContent = "";
+        boardEl.textContent = "";
 
         this.grid.forEach(row => {
-            row.forEach(cell => board.append(cell.getElement()))
+            row.forEach(cell => boardEl.append(cell.getElement()))
         });
     }
 

--- a/src/board.ts
+++ b/src/board.ts
@@ -127,14 +127,16 @@ export class Board {
         const randomCol = this.random(0, this.mode.cols);
         const distance = Session.get("firstClick") as number;
 
-        const outOfSafeArea = (randomRow > centerRow + distance || randomRow < centerRow - distance)
-            && (randomCol > centerCol + distance || randomCol < centerCol - distance);
+        const outOfSafeArea =
+            (randomRow > centerRow + distance || randomRow < centerRow - distance) &&
+            (randomCol > centerCol + distance || randomCol < centerCol - distance);
 
-        if (!outOfSafeArea || this.grid[randomRow][randomCol].isMine()) {
-            this.replantMine(centerRow, centerCol);
-        } else {
+        if (outOfSafeArea && !this.grid[randomRow][randomCol].isMine()) {
             this.grid[randomRow][randomCol].setMine();
+            return;
         }
+
+        this.replantMine(centerRow, centerCol);
     }
 
     private random(from: number, to: number): number {

--- a/src/game.ts
+++ b/src/game.ts
@@ -55,7 +55,7 @@ export class Game {
         PubSub.subscribe(EVENT_CELL_FLAGGED, this.incrementFlags.bind(this));
         PubSub.subscribe(EVENT_CELL_UNFLAGGED, this.decrementFlags.bind(this));
         PubSub.subscribe(EVENT_GAME_OVER, this.gameOver.bind(this));
-        PubSub.subscribe(EVENT_SAFE_AREA_CREATED, this.updateHash.bind(this));
+        PubSub.subscribe(EVENT_SAFE_AREA_CREATED, this.updateUrlHash.bind(this));
 
         this.initialize();
     }
@@ -131,7 +131,7 @@ export class Game {
 
         this.board = new Board(mode, state);
 
-        this.urlTool.updateHash(mode, this.board.getState());
+        this.updateUrlHash();
     }
 
     private start(): void {
@@ -173,9 +173,8 @@ export class Game {
         this.setFlags(--this.flagsCounter);
     }
 
-    private updateHash(): void {
-        const mode = this.urlTool.extractMode();
-        this.urlTool.updateHash(mode, this.board.getState());
+    private updateUrlHash(): void {
+        this.urlTool.updateHash(this.board.getMode(), this.board.getState());
     }
 
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,11 +4,11 @@ import { CantorPairer } from "./pairer/cantorPairer";
 import { BinaryToBase64UrlEncoderV2 } from "./encoder/binaryToBase64UrlEncoderV2";
 
 const config: Config = {
-    mode: MODE_NAME.Beginner,
+    mode: MODE_NAME.Expert,
     encoder: BinaryToBase64UrlEncoderV2.prototype,
     modePairer: CantorPairer.prototype,
     firstClick: FIRST_CLICK.GuaranteedCascade,
-    debug: true,
+    debug: false,
 }
 
 new Game(config);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,11 +4,11 @@ import { CantorPairer } from "./pairer/cantorPairer";
 import { BinaryToBase64UrlEncoderV2 } from "./encoder/binaryToBase64UrlEncoderV2";
 
 const config: Config = {
-    mode: MODE_NAME.Expert,
+    mode: MODE_NAME.Beginner,
     encoder: BinaryToBase64UrlEncoderV2.prototype,
     modePairer: CantorPairer.prototype,
     firstClick: FIRST_CLICK.GuaranteedCascade,
-    debug: false,
+    debug: true,
 }
 
 new Game(config);


### PR DESCRIPTION
This PR removes the need for constantly keeping in sync the board's grid and state. Now the state is used only as a payload for planting the mines and can be extracted from the current grid at a later time if needed instead of always keeping it up-to-date whenever some change in the positioning of the mines happens.