### PR TITLE
Updated version of Comment on released PRs action

### DIFF
--- a/.github/workflows/commentReleasedPRs.yml
+++ b/.github/workflows/commentReleasedPRs.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment released PRs
-        uses: rdlf0/comment-released-prs-action@v1
+        uses: rdlf0/comment-released-prs-action@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR simply updates the action for [commenting on the released PRs](https://github.com/rdlf0/comment-released-prs-action/releases/latest) to the latest available version at the moment.