### PR TITLE
Changed Reset and Replay behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   - [Compile](#compile)
   - [Download precompiled](#download-precompiled)
   - [Play online](#play-online)
-- [Settings](#settings)
+- [Settings](#settings-)
 - [Game modes](#game-modes)
 - [First click options](#first-click-options)
 - [Game start options](#game-start-options)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 ![](https://github.com/rdlf0/minesweeper/workflows/CI/CD/badge.svg)
 
 # Minesweeper
+
+## Table of contents
+- [Requirements](#requirements)
+- [Getting it up and running](#getting-it-up-and-running)
+  - [Compile](#compile)
+  - [Download precompiled](#download-precompiled)
+  - [Play online](#play-online)
+- [Settings](#settings)
+- [Game modes](#game-modes)
+- [First click options](#first-click-options)
+- [Game start options](#game-start-options)
+
 ## Requirements
 - typescript v3 or later (if you choose the compile option below)
 - a non-ancient browser
@@ -13,7 +25,7 @@ There are 3 options from which you can choose:
     $ tsc
     ```
     After that open the `index.html`.
-- ### Download already compiled
+- ### Download precompiled
     Simply download the asset from the [latest release](https://github.com/rdlf0/minesweeper/releases/latest), unzip and just open `index.html`.
 - ### Play online  
     Enjoy the published version of the game at [http://rdlf0-minesweeper.s3-website.us-east-2.amazonaws.com/](http://rdlf0-minesweeper.s3-website.us-east-2.amazonaws.com/)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _*** will probably not become available to the user_
 | from URL | from settings | random |
 | from URL with hash | from hash | from hash |
 | reset | from settings | random |
-| replay | from settings | from current board |
+| replay | from current board | from current board |
 
 _**** Represents the positioning of the mines_
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _*** will probably not become available to the user_
 | ------ | ---- | ----- |
 | from URL | from settings | random |
 | from URL with hash | from hash | from hash |
-| reset | from settings | random |
+| reset | from current board | random |
 | replay | from current board | from current board |
 
 _**** Represents the positioning of the mines_

--- a/src/game.ts
+++ b/src/game.ts
@@ -59,6 +59,10 @@ export class Game {
     }
 
     private reset(): void {
+        if (Session.get("debug")) {
+            console.debug('======= RESET =======');
+        }
+
         history.replaceState(undefined, undefined, "#");
         this.timer.stop();
         this.isReset = true;
@@ -68,6 +72,10 @@ export class Game {
     }
 
     private replay(): void {
+        if (Session.get("debug")) {
+            console.debug('======= REPLAY =======');
+        }
+
         this.timer.stop();
         this.isReset = false;
         this.isReplay = true;
@@ -105,7 +113,7 @@ export class Game {
             state = null;
             Session.set("applyFirstClickRule", true);
         } else if (this.isReplay) {
-            // Same as Starter.Hash, but here we avoid decoding and unpairing
+            // Same as if started by a URL with a hash, but here we avoid decoding and unpairing
             mode = this.board.getMode();
             state = this.board.getState();
         } else if (this.urlTool.isHashSet()) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,7 +1,7 @@
 import { Board } from "./board";
 import { Timer } from "./timer";
 import { Counter } from "./counter";
-import { Config, Mode, BOARD_CONFIG } from "./config";
+import { Config, Mode, BOARD_CONFIG, MODE_NAME } from "./config";
 import { State } from "./state";
 import { UrlTool } from "./urlTool";
 import {
@@ -86,11 +86,15 @@ export class Game {
         this.starter = this.determineStarter();
         this.isOver = false;
         this.timer.reset();
-        this.board?.unsubscribe();
+
+        if (this.board != null) { // Microsoft Edge Mobile doesn't support optional chaining yet
+            this.board.unsubscribe();
+        }
         this.generateScenario();
 
         const boardEl = document.getElementById("board");
-        boardEl.classList.add(`board-${this.config.mode}`);
+        const boardMode = this.findModeNameByMode(this.board.getMode());
+        boardEl.classList.add(`board-${boardMode}`);
         this.board.draw(boardEl);
 
         this.setFlags(0);
@@ -132,6 +136,23 @@ export class Game {
         this.board = new Board(mode, state);
 
         this.updateUrlHash();
+    }
+
+    private findModeNameByMode(mode: Mode): MODE_NAME {
+        if (mode == null) {
+            return null;
+        }
+
+        let modeName: MODE_NAME;
+        for (modeName in BOARD_CONFIG) {
+            if (mode.rows == BOARD_CONFIG[modeName].rows
+                && mode.cols == BOARD_CONFIG[modeName].cols
+                && mode.mines == BOARD_CONFIG[modeName].mines) {
+                return modeName;
+            }
+        }
+
+        return null;
     }
 
     private start(): void {

--- a/src/game.ts
+++ b/src/game.ts
@@ -94,6 +94,7 @@ export class Game {
 
         const boardEl = document.getElementById("board");
         const boardMode = this.findModeNameByMode(this.board.getMode());
+        boardEl.className = boardEl.className.replace(/board-\w*/g, '');
         boardEl.classList.add(`board-${boardMode}`);
         this.board.draw(boardEl);
 
@@ -121,7 +122,8 @@ export class Game {
 
         switch (this.starter) {
             case Starter.Replay:
-                mode = BOARD_CONFIG[this.config.mode];
+                // Same as Starter.Hash, but here we avoid decoding and unpairing
+                mode = this.board.getMode();
                 state = this.board.getState();
                 break;
             case Starter.Hash:

--- a/src/urlTool.ts
+++ b/src/urlTool.ts
@@ -19,7 +19,7 @@ export class UrlTool {
     }
 
     private getDecodedHash(): string {
-        if (this.isHashSet() && this.decodedHash.length == 0) {
+        if (this.isHashSet()) {
             this.decodedHash = this.encoder.decode(window.location.hash.slice(1));
         }
 

--- a/src/util/pub-sub.ts
+++ b/src/util/pub-sub.ts
@@ -13,9 +13,9 @@ export const EVENT_SAFE_AREA_CREATED = "safeAreaCreated";
 
 export class PubSub {
 
-    private constructor() { };
+    private constructor() { }
 
-    private static events: Array<Array<callbackFunc>> = new Array();
+    private static events: { [eventName: string]: Array<callbackFunc> } = {};
 
     public static subscribe(eventName: string, func: callbackFunc): void {
         PubSub.events[eventName] = PubSub.events[eventName] || [];

--- a/src/util/session.ts
+++ b/src/util/session.ts
@@ -2,16 +2,16 @@ type ValueType = string | number | boolean;
 
 export class Session {
 
-    private constructor() { };
+    private constructor() { }
 
     private static data: Map<string, ValueType> = new Map();
 
     public static set(key: string, value: ValueType): void {
+        Session.data.set(key, value);
+
         if (Session.get("debug")) {
             console.debug(`SESSION SET: ${key} = ${value}`);
         }
-
-        Session.data.set(key, value);
     }
 
     public static get(key: string, defaultValue?: ValueType): ValueType {

--- a/styles.css
+++ b/styles.css
@@ -59,7 +59,7 @@ main {
 }
 
 #controls .control {
-    margin: 10rem;
+    margin: 7rem;
 }
 
 #controls .buttons-wrapper {


### PR DESCRIPTION
This PR modifies what happens when Reset or Replay is clicked. Now, when any of the two actions occurs, the mode for the new board comes from the current board instead of getting it from the config, which allows for keeping the mode in which the player played last. Another change in this PR is that now the board correctly resizes according to the newly passed hash. Also, some minor refactoring is included.