### PR TITLE
Bump the versions of the used GH actions

### DIFF
--- a/.github/workflows/commentReleasedPRs.yml
+++ b/.github/workflows/commentReleasedPRs.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Comment released PRs
-        uses: rdlf0/comment-released-prs-action@v2
+        uses: rdlf0/comment-released-prs-action@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          add-label: true

--- a/.github/workflows/compilabilityCheck.yml
+++ b/.github/workflows/compilabilityCheck.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Check out the code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Compile
       run: tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       ASSET_TYPE: application/zip
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
 
@@ -32,7 +32,7 @@ jobs:
         run: zip -r $ASSET_NAME $ARTIFACT_PATH
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./${{ env.ARTIFACT_PATH }}
@@ -63,7 +63,7 @@ jobs:
       contents: read
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
 


### PR DESCRIPTION
This PR contains only version bumps of the referenced GitHub actions in the different workflows.