### PR TITLE
Bumped GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,9 @@ jobs:
     env:
       ARTIFACT_PATH: artifact
       ASSET_NAME: minesweeper.zip
-      ASSET_TYPE: application/zip
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
 
@@ -32,20 +31,16 @@ jobs:
         run: zip -r $ASSET_NAME $ARTIFACT_PATH
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./${{ env.ARTIFACT_PATH }}
 
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: AButler/upload-release-assets@v3.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ env.ASSET_NAME }}
-          asset_name: ${{ env.ASSET_NAME }}
-          asset_content_type: ${{ env.ASSET_TYPE }}
+          files: "./${{ env.ASSET_NAME }}"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     name: Deploy
@@ -63,12 +58,12 @@ jobs:
       contents: read
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
This PR bumps the versions of a few GitHub actions and also replaces the unmaintained `actions/upload-release-asset` with `AButler/upload-release-assets`.