### PR TITLE
Fix deploy again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           do
               echo "Uploading ${files[$i]}"
 
-              aws s3 sync $ARTIFACT_NAME s3://$AWS_S3_BUCKET \
+              aws s3 sync . s3://$AWS_S3_BUCKET \
                     --delete \
                     --acl public-read \
                     --exclude "*" \


### PR DESCRIPTION
Fixed source path for `s3 sync` since [the changed behavior](https://github.com/actions/download-artifact/tree/v3?tab=readme-ov-file#compatibility-between-v1-and-v2v3) of actions/download-artifact wasn't taken into account.