### PR TITLE
Added hints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+A browser-based Minesweeper game written in vanilla TypeScript with **no third-party
+dependencies, frameworks, or build tooling beyond `tsc`** (see `CONTRIBUTING.md` —
+"keep it as simple as possible" is the project's first rule). There is no
+`package.json` and no `node_modules`; TypeScript is expected to be installed globally.
+The live game is at theminesweeper.com.
+
+## Commands
+
+```sh
+tsc                      # compile src/**/*.ts -> dist/ (native ES modules, ES2020)
+tsc --noEmit             # type-check only, no build
+tsc --sourceMap -w       # watch mode with source maps, for local development
+npx serve                # serve the project root over HTTP for local play (needs Node)
+tsc && node --test       # build, then run the unit tests (Node's built-in runner)
+```
+
+After compiling, serve the project root over HTTP and open the printed URL in a
+browser — e.g. `npx serve`. Opening `index.html` from the filesystem will **not** work:
+the app loads as native ES modules (`<script type="module" src="dist/main.js">`), which
+browsers refuse to load over `file://`. Production (S3) and the release zip serve over
+HTTP, so they're unaffected.
+
+Tests live in `test/*.test.mjs` and run on Node's built-in runner (`node:test` +
+`node:assert`, **no test framework or third-party deps**). They import the compiled
+`dist/*.js`, so build first: `tsc && node --test`. Coverage is the pure-logic modules
+only — pairers, encoders, `State` (the URL round-trip pipeline); the DOM-heavy parts
+(`Board`, `Cell`, `Game`) are not unit-tested. No linter is configured. CI runs
+`tsc && node --test` on every non-`master` branch (type-check + unit tests); releases
+compile and deploy the static files to S3. Both
+workflows pin `typescript@6.0.3` (installed via `npm i -g`) so the runner can't drift
+— bump both `.github/workflows/*.yml` together if you upgrade. The compiler is the
+quality gate: `tsconfig.json` runs full `strict` mode (only `strictPropertyInitialization`
+is disabled, because fields are assigned in `initialize()` lifecycle methods, not the
+constructor).
+
+## Architecture
+
+The app is event-driven. Components never call each other directly across domains —
+they communicate through a global static `PubSub` (`src/util/pub-sub.ts`) using the
+`EVENT_*` string constants defined there. When adding behavior, prefer publishing /
+subscribing over wiring direct method calls.
+
+Core flow:
+
+- **`main.ts`** — entry point. Builds the `Config` object (mode, encoder, pairer,
+  first-click rule, dark mode, debug flag) and instantiates `Game`. This is the one
+  place to swap which `Encoder` / `Pairer` implementation is used.
+- **`Game`** (`game.ts`) — orchestrator. Owns the UI controls (counter, timer, reset
+  / replay / settings buttons), subscribes to game events, and drives `initialize()`
+  which decides how a board is created: reset, replay, from a URL hash, or fresh from
+  config. Reacts to `hashchange` and settings changes by re-initializing.
+- **`Board`** (`board.ts`) — the grid of `Cell`s. Plants mines (randomly, or decoded
+  from a `State`), computes adjacent-cell values, handles cascade reveals, enforces
+  the first-click safe-area rule (`makeSafeArea` / `replantMine`), and detects win.
+- **`Cell`** (`cell.ts`) — a single square plus its DOM element. Implements
+  `handleEvent` (it registers *itself* as the click/contextmenu listener). Reveal /
+  flag / question transitions publish the relevant events. Cell `value` doubles as
+  state: `-2` = default, `-1` = mine, `0..8` = adjacent mine count.
+- **`Session`** (`util/session.ts`) — a static in-memory key/value store for
+  cross-cutting per-game flags (`debug`, `firstClick`, `gameStarted`,
+  `applyFirstClickRule`). Cleared on every `initialize()`.
+
+### Board sharing via URL hash (`urlTool.ts` + encoder + pairer)
+
+A board is fully reproducible from the URL hash, which is how "replay" and
+share-a-board work. The encoding pipeline:
+
+1. The mode `{rows, cols, mines}` is folded into a single integer using a **pairing
+   function** (`src/pairer/`, e.g. `CantorPairer`) — nested pairing of (rows,cols)
+   then with mines.
+2. That integer (as a fixed 24-bit binary string, `MODE_SIZE`) is concatenated with
+   the mine layout — the `State` bitstring (`state.ts`, one bit per cell).
+3. The combined binary string is run through an **`Encoder`** (`src/encoder/`, e.g.
+   `BinaryToBase64UrlEncoderV2`) to produce the URL-safe hash, set via
+   `history.replaceState`.
+
+Decoding reverses this. `extractMode` validates the result (min rows/cols,
+mines-to-cells ratio) and returns `null` on anything malformed, so callers must handle
+the fallback. `Pairer` and `Encoder` are interfaces with interchangeable
+implementations selected in `main.ts`; the encoder/pairer chosen must stay consistent
+between encode and decode, so changing the default in `main.ts` invalidates
+previously shared URLs.
+
+## Conventions
+
+- Keep it dependency-free and simple (the explicit contributing rule).
+- `// nosonar` comments suppress SonarQube findings — leave them in place.
+- Work happens on feature branches off `master` via PRs (see `CONTRIBUTING.md`);
+  `master` is protected and CI-gated.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ After that open the printed URL (e.g. http://localhost:3000) in your browser.
 | ------- | ------- | ------- |
 | mode | `beginner`, `intermediate`, `expert` | `expert` |
 | first click * | `guaranteed non-mine`, `guaranteed cascade` | `guaranteed cascade` |
+| hint shows | `mines`, `safe cells` | `mines` |
 | dark mode | `enabled`, `disabled` | `enabled` |
 | debug ** | `true`, `false` | `false` |
 
@@ -47,6 +48,14 @@ _** will probably not become available to the user_
 | ------ | ------- |
 | `guaranteed non-mine` | the first clicked cell has a value between 0 and 8 |
 | `guaranteed cascade` | the first clicked cell has a value of 0 |
+
+## Hint options
+The hint button (💡) runs a built-in logic solver over the current board and highlights every cell it can prove, each with an explanation shown on hover. It never guesses — only cells that logic guarantees are highlighted — and it reasons purely from what's on the board, so every explanation is checkable at a glance. Each hint costs the player some time (added to the timer); the cost is shown in the button's tooltip.
+
+| Option | Meaning |
+| ------ | ------- |
+| `mines` | highlight the cells that are provably mines (pulsing red) |
+| `safe cells` | highlight the cells that are provably safe to reveal (pulsing green) |
 
 ## Game start options
 | Option | Mode | State *** |

--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
                 <div id="replay" class="control" title="Replay">
                     <div class="icon"></div>
                 </div>
+                <div id="hint" class="control" title="Get a hint">
+                    <div class="icon"></div>
+                </div>
                 <div id="toggle-settings" class="control" title="Settings">
                     <div class="icon"></div>
                 </div>
@@ -42,6 +45,7 @@
         </div>
         <div id="board"></div>
         <div id="settings"></div>
+        <div id="hint-message"></div>
     </main>
     <script type="text/javascript" src="pwa-resize.js"></script>
 </body>

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,8 +1,10 @@
 import { Cell } from "./cell.js";
-import { Mode, FIRST_CLICK } from "./config.js";
+import { Mode, FIRST_CLICK, HINT_MODE } from "./config.js";
 import { State } from "./state.js";
+import { solve, CellView } from "./solver/minesweeperSolver.js";
 import {
     EVENT_CELL_CLICKED,
+    EVENT_CELL_FLAGGED,
     EVENT_CELL_REVEALED,
     EVENT_GAME_OVER,
     EVENT_SAFE_AREA_CREATED,
@@ -23,10 +25,21 @@ export class Board {
 
     private revealedCounter: number = 0;
 
+    private hintedCells: Cell[] = [];
+
+    private hintHovers: { cell: Cell; enter: () => void; leave: () => void; refs: { cell: Cell; kind: string }[] }[] = [];
+
+    // Whether the currently shown hints are mines (cleared on flag) rather than
+    // safe cells (cleared on reveal).
+    private hintDanger: boolean = false;
+
     private eventSubscribers: EventSubscriber[] = [
         { event: EVENT_CELL_CLICKED, subscriber: this.secureSafeArea.bind(this) },
+        { event: EVENT_CELL_CLICKED, subscriber: this.clearHintsOnReveal.bind(this) },
+        { event: EVENT_CELL_FLAGGED, subscriber: this.clearHintsOnFlag.bind(this) },
         { event: EVENT_CELL_REVEALED, subscriber: this.calculateCellValue.bind(this) },
         { event: EVENT_CELL_REVEALED, subscriber: this.incrementRevealed.bind(this) },
+        { event: EVENT_GAME_OVER, subscriber: this.clearHints.bind(this) },
     ];
 
     constructor(
@@ -247,6 +260,64 @@ export class Board {
                 cell.getElement().addEventListener("contextmenu", e => e.preventDefault());
             }
         }
+    }
+
+    public showHint(mode: HINT_MODE): number {
+        this.clearHints();
+
+        const view: CellView[][] = this.grid.map(row =>
+            row.map(cell => ({
+                revealed: cell.isRevealed(),
+                flagged: cell.isFlagged(),
+                value: cell.isRevealed() ? cell.getValue() : 0,
+            }))
+        );
+
+        const result = solve(view);
+        const danger = mode === HINT_MODE.Mines;
+        this.hintDanger = danger;
+        const cells = danger ? result.mines : result.safe;
+        for (const { row, col, reason, references } of cells) {
+            const cell = this.grid[row][col];
+            cell.setHint(reason, danger);
+            this.hintedCells.push(cell);
+
+            const refs = references.map(([r, c], i) => ({
+                cell: this.grid[r][c],
+                kind: i === 0 ? "a" : "b",
+            }));
+            const enter = () => refs.forEach(({ cell, kind }) => cell.addReference(kind));
+            const leave = () => refs.forEach(({ cell }) => cell.clearReference());
+            const el = cell.getElement();
+            el.addEventListener("mouseenter", enter);
+            el.addEventListener("mouseleave", leave);
+            this.hintHovers.push({ cell, enter, leave, refs });
+        }
+
+        return cells.length;
+    }
+
+    private clearHintsOnReveal(): void {
+        this.clearHints();
+    }
+
+    private clearHintsOnFlag(): void {
+        if (this.hintDanger) {
+            this.clearHints();
+        }
+    }
+
+    public clearHints(): void {
+        this.hintedCells.forEach(cell => cell.clearHint());
+        this.hintedCells = [];
+
+        this.hintHovers.forEach(({ cell, enter, leave, refs }) => {
+            const el = cell.getElement();
+            el.removeEventListener("mouseenter", enter);
+            el.removeEventListener("mouseleave", leave);
+            refs.forEach(ref => ref.cell.clearReference());
+        });
+        this.hintHovers = [];
     }
 
     private incrementRevealed(): void {

--- a/src/cell.ts
+++ b/src/cell.ts
@@ -87,6 +87,35 @@ export class Cell {
         return this.state === CellState.Flagged;
     }
 
+    public isRevealed(): boolean {
+        return this.state === CellState.Revealed;
+    }
+
+    public getValue(): number {
+        return this.value;
+    }
+
+    public setHint(reason: string, danger: boolean): void {
+        this.el.classList.add("hint");
+        if (danger) {
+            this.el.classList.add("hint-danger");
+        }
+        this.el.setAttribute("title", reason);
+    }
+
+    public clearHint(): void {
+        this.el.classList.remove("hint", "hint-danger");
+        this.el.removeAttribute("title");
+    }
+
+    public addReference(kind: string): void {
+        this.el.classList.add(`hint-ref-${kind}`);
+    }
+
+    public clearReference(): void {
+        this.el.classList.remove("hint-ref-a", "hint-ref-b");
+    }
+
     public setWronglyFlagged(): void {
         this.setState(CellState.WronglyFlagged);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,9 @@ export interface Config {
     encoder: Encoder;
     modePairer: Pairer;
     firstClick: FIRST_CLICK;
+    hintMode: HINT_MODE;
+    /** Seconds added to the timer each time a hint is shown. */
+    hintCost: number;
     debug: boolean;
     darkModeOn: boolean;
     github: GitHub
@@ -20,6 +23,11 @@ interface GitHub {
 export enum FIRST_CLICK {
     GuaranteedNonMine = 0,
     GuaranteedCascade = 1,
+}
+
+export enum HINT_MODE {
+    Mines = "mines",
+    Safe = "safe",
 }
 
 export enum MODE_NAME {

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,7 +1,7 @@
 import { Board } from "./board.js";
 import { Timer } from "./timer.js";
 import { Counter } from "./counter.js";
-import { Config, Mode, BOARD_CONFIG, MODE_NAME } from "./config.js";
+import { Config, Mode, BOARD_CONFIG, MODE_NAME, HINT_MODE } from "./config.js";
 import { State } from "./state.js";
 import { UrlTool } from "./urlTool.js";
 import {
@@ -12,6 +12,7 @@ import {
     EVENT_SAFE_AREA_CREATED,
     EVENT_SETTINGS_CHANGED,
     EVENT_MODE_CHANGED,
+    EVENT_HINT_MODE_CHANGED,
     PubSub,
 } from "./util/pub-sub.js";
 import { Session } from "./util/session.js";
@@ -23,11 +24,17 @@ export class Game {
     private counter: Counter;
     private resetBtn: HTMLElement;
     private replayBtn: HTMLElement;
+    private hintBtn: HTMLElement;
     private toggleSettingsBtn: HTMLElement;
     private timer: Timer;
     private board: Board;
     private boardEl: HTMLElement;
     private settingsEl: HTMLElement;
+    private hintMessageEl: HTMLElement;
+    private hintMessageTimeout: number | undefined;
+    // Blocks re-invoking the hint until the player makes a move.
+    private hintUsed: boolean = false;
+    private lastHintMessage: string | undefined;
 
     // Other properties
     private flagsCounter: number;
@@ -49,11 +56,16 @@ export class Game {
         this.replayBtn = document.getElementById("replay")!;
         this.replayBtn.addEventListener("click", this.replay.bind(this));
 
+        this.hintBtn = document.getElementById("hint")!;
+        this.hintBtn.title = `Get a hint (+${this.config.hintCost}s)`;
+        this.hintBtn.addEventListener("click", this.showHint.bind(this));
+
         this.toggleSettingsBtn = document.getElementById("toggle-settings")!;
         this.toggleSettingsBtn.addEventListener("click", this.toggleSettings.bind(this));
 
         this.boardEl = document.getElementById("board")!;
         this.settingsEl = document.getElementById("settings")!;
+        this.hintMessageEl = document.getElementById("hint-message")!;
         window.addEventListener("hashchange", this.handleHashChange.bind(this));
 
         this.urlTool = new UrlTool(
@@ -62,7 +74,10 @@ export class Game {
         );
 
         PubSub.subscribe(EVENT_CELL_REVEALED, this.start.bind(this));
+        PubSub.subscribe(EVENT_CELL_REVEALED, this.allowHint.bind(this));
         PubSub.subscribe(EVENT_CELL_FLAGGED, this.incrementFlags.bind(this));
+        PubSub.subscribe(EVENT_CELL_FLAGGED, this.allowHint.bind(this));
+        PubSub.subscribe(EVENT_HINT_MODE_CHANGED, this.allowHint.bind(this));
         PubSub.subscribe(EVENT_CELL_UNFLAGGED, this.decrementFlags.bind(this));
         PubSub.subscribe(EVENT_GAME_OVER, this.gameOver.bind(this));
         PubSub.subscribe(EVENT_SAFE_AREA_CREATED, this.updateUrlHash.bind(this));
@@ -92,6 +107,56 @@ export class Game {
         this.initialize(false, true);
     }
 
+    private showHint(): void {
+        if (this.isOver || this.settingsOpened) {
+            return;
+        }
+
+        if (!this.isStarted()) {
+            this.flashHintMessage("Click any cell — your first move is always safe.");
+            return;
+        }
+
+        if (this.hintUsed) {
+            if (this.lastHintMessage !== undefined) {
+                this.flashHintMessage(this.lastHintMessage);
+            }
+            return;
+        }
+
+        const found = this.board.showHint(this.config.hintMode);
+
+        // Using the helper costs the player time, even when it finds nothing.
+        this.timer.addTime(this.config.hintCost);
+        this.hintUsed = true;
+
+        if (found === 0) {
+            this.lastHintMessage = this.config.hintMode === HINT_MODE.Mines
+                ? "No mine can be logically pinned down yet."
+                : "No logical move — you'll have to take a guess.";
+            this.flashHintMessage(this.lastHintMessage);
+        } else {
+            this.lastHintMessage = undefined;
+        }
+    }
+
+    private allowHint(): void {
+        this.hintUsed = false;
+        this.lastHintMessage = undefined;
+    }
+
+    private flashHintMessage(message: string): void {
+        this.hintMessageEl.textContent = message;
+        this.hintMessageEl.classList.add("show");
+
+        if (this.hintMessageTimeout !== undefined) {
+            clearTimeout(this.hintMessageTimeout);
+        }
+        this.hintMessageTimeout = window.setTimeout(() => {
+            this.hintMessageEl.classList.remove("show");
+        }, 3000);
+    }
+
     private handleHashChange(): void {
         this.logDebugMessage('======= HASH CHANGED =======');
 
@@ -119,6 +184,8 @@ export class Game {
         this.isReset = isReset;
         this.isReplay = isReplay;
         this.isOver = false;
+        this.hintUsed = false;
+        this.lastHintMessage = undefined;
         this.timer.stop();
         this.timer.reset();
         this.board?.unsubscribe();
@@ -191,6 +258,8 @@ export class Game {
 
     private openSettings(): void {
         this.timer.stop();
+        this.board.clearHints();
+        this.allowHint();
         this.settingsOpened = true;
         this.boardEl.style.display = "none";
         this.settingsEl.style.display = "flex";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Game } from "./game.js";
-import { FIRST_CLICK, MODE_NAME, Config } from "./config.js";
+import { FIRST_CLICK, HINT_MODE, MODE_NAME, Config } from "./config.js";
 import { CantorPairer } from "./pairer/cantorPairer.js";
 import { BinaryToBase64UrlEncoderV2 } from "./encoder/binaryToBase64UrlEncoderV2.js";
 
@@ -8,6 +8,8 @@ const config: Config = {
     encoder: BinaryToBase64UrlEncoderV2.prototype,
     modePairer: CantorPairer.prototype,
     firstClick: FIRST_CLICK.GuaranteedCascade,
+    hintMode: HINT_MODE.Mines,
+    hintCost: 10,
     debug: false,
     darkModeOn: true,
     github: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,9 +1,10 @@
-import { BOARD_CONFIG, Config, FIRST_CLICK, Mode, MODE_NAME } from "./config.js";
-import { EVENT_MODE_CHANGED, EVENT_SETTINGS_CHANGED, PubSub } from "./util/pub-sub.js";
+import { BOARD_CONFIG, Config, FIRST_CLICK, HINT_MODE, Mode, MODE_NAME } from "./config.js";
+import { EVENT_HINT_MODE_CHANGED, EVENT_MODE_CHANGED, EVENT_SETTINGS_CHANGED, PubSub } from "./util/pub-sub.js";
 
 enum AVAILABLE_SETTINGS {
     mode = "Mode",
     firstClick = "First click",
+    hintMode = "Hint shows",
     darkMode = "Dark mode",
     about = "About",
 }
@@ -38,6 +39,7 @@ export class Settings {
         switch (setting) {
             case "mode": this.drawMode(settingFieldset); break;
             case "firstClick": this.drawFirstClick(settingFieldset); break;
+            case "hintMode": this.drawHintMode(settingFieldset); break;
             case "darkMode": this.drawDarkMode(settingFieldset); break;
             case "about": this.drawAbout(settingFieldset); break;
         }
@@ -65,19 +67,33 @@ export class Settings {
     }
 
     private drawFirstClick(fieldset: HTMLElement) {
-        Object.keys(FIRST_CLICK).forEach(firstClickKey => {
-            if (!isNaN(Number(firstClickKey))) {
-                return;
-            }
+        const options: { label: string, value: FIRST_CLICK }[] = [
+            { label: "Guaranteed non-mine", value: FIRST_CLICK.GuaranteedNonMine },
+            { label: "Guaranteed cascade", value: FIRST_CLICK.GuaranteedCascade },
+        ];
+        options.forEach(({ label, value }) => {
+            this.drawRadioButton(fieldset, "firstClick", label, value.toString(), this.config.firstClick == value, () => {
+                this.config.firstClick = value;
+                this.drawFieldset("firstClick", fieldset);
+                PubSub.publish(EVENT_SETTINGS_CHANGED);
+            });
+        });
+    }
 
-            const value = FIRST_CLICK[firstClickKey as keyof typeof FIRST_CLICK];
-            this.drawRadioButton(
-                fieldset,
-                firstClickKey,
-                "firstClick",
-                value.toString(),
-                this.config.firstClick == value);
-        })
+    private drawHintMode(fieldset: HTMLElement) {
+        const options: { label: string, value: HINT_MODE }[] = [
+            { label: "Mines", value: HINT_MODE.Mines },
+            { label: "Safe cells", value: HINT_MODE.Safe },
+        ];
+        options.forEach(({ label, value }) => {
+            this.drawRadioButton(fieldset, "hintMode", label, value, this.config.hintMode === value, () => {
+                this.config.hintMode = value;
+                this.drawFieldset("hintMode", fieldset);
+                // Only changes what the hint button reveals — no board reset, so
+                // this deliberately doesn't publish EVENT_SETTINGS_CHANGED.
+                PubSub.publish(EVENT_HINT_MODE_CHANGED);
+            });
+        });
     }
 
     private drawDarkMode(fieldset: HTMLElement) {
@@ -167,27 +183,24 @@ export class Settings {
         parent.appendChild(wrapper);
     }
 
-    private drawRadioButton(parent: HTMLElement, labelText: string, name: string, value: string, checked: boolean) {
+    private drawRadioButton(parent: HTMLElement, name: string, labelText: string, value: string, checked: boolean, onSelect: () => void) {
         const wrapper = document.createElement("div");
         parent.appendChild(wrapper);
 
+        const id = `${name}_${value}`;
+
         const label = document.createElement("label");
-        label.textContent =
-            labelText == FIRST_CLICK[FIRST_CLICK.GuaranteedNonMine]
-                ? "Guaranteed non-mine"
-                : "Guaranteed cascade";
-        label.setAttribute("for", labelText);
+        label.textContent = labelText;
+        label.setAttribute("for", id);
         wrapper.appendChild(label);
 
         const radio = document.createElement("input")
         radio.setAttribute("type", "radio")
-        radio.setAttribute("id", labelText)
+        radio.setAttribute("id", id)
         radio.setAttribute("name", name)
-        radio.setAttribute("data-configKey", name)
-        radio.setAttribute("data-configValue", value);
         radio.checked = checked;
         if (!checked) {
-            radio.addEventListener("click", this.updateConfig.bind(this, parent));
+            radio.addEventListener("click", onSelect);
         }
         wrapper.appendChild(radio);
     }
@@ -219,7 +232,7 @@ ${navigator.userAgent}`;
         if (configKey == null) {
             return;
         }
-        // Dynamic write of a config field (mode / firstClick) from a DOM attribute string
+        // Dynamic write of a config field (mode) from a DOM attribute string
         (this.config as any)[configKey] = target.getAttribute("data-configValue");
         this.drawFieldset(configKey as keyof typeof AVAILABLE_SETTINGS, fieldset);
         PubSub.publish(EVENT_SETTINGS_CHANGED)

--- a/src/solver/minesweeperSolver.ts
+++ b/src/solver/minesweeperSolver.ts
@@ -1,0 +1,241 @@
+/**
+ * A pure, dependency-free Minesweeper solver.
+ *
+ * It operates on a read-only snapshot of the board's *visible* state (what a
+ * player can see) and returns the cells that are provably safe to reveal and the
+ * cells that are provably mines, each with a short human-readable explanation of
+ * why. It never guesses: a cell is reported only when logic guarantees its state.
+ *
+ * Two deduction rules are applied, each judged against the *visible* board only
+ * (revealed numbers and flags):
+ *  1. Single-number — a revealed number whose mines are all flagged makes its
+ *     remaining hidden neighbors safe (and, conversely, pins mines).
+ *  2. Overlap — for two numbers A and B sharing hidden cells, if A needs exactly
+ *     as many more mines than B as it has cells B lacks, then every cell unique
+ *     to A is a mine and every cell unique to B is safe. This is the general form
+ *     of the classic 1-2-1 / 1-1 patterns and the reduced-number cases (e.g. a
+ *     "3" next to a flag behaves like a "2"); the subset rule is its special case.
+ *
+ * Deductions are deliberately NOT fed back for further rounds — only
+ * "first-level" hints are reported. A chained conclusion rests on other hints,
+ * so its explanation can't be verified by just looking at the board; everything
+ * reported here is checkable directly against what the player can see.
+ *
+ * The caller chooses which set to surface (safe cells or mines); the DOM knows
+ * nothing about this module.
+ */
+
+export interface CellView {
+    revealed: boolean;
+    flagged: boolean;
+    /** Adjacent-mine count; only meaningful when `revealed` is true. */
+    value: number;
+}
+
+export interface HintCell {
+    row: number;
+    col: number;
+    reason: string;
+    /**
+     * The revealed number cells the explanation talks about, so the UI can
+     * highlight them when the player inspects this hint.
+     */
+    references: Array<[number, number]>;
+}
+
+export interface SolveResult {
+    /** Cells provably safe to reveal. */
+    safe: HintCell[];
+    /** Cells provably containing a mine. */
+    mines: HintCell[];
+}
+
+type Coord = [number, number];
+
+const UNKNOWN = 0;
+const SAFE = 1;
+const MINE = 2;
+
+interface Constraint {
+    row: number;
+    col: number;
+    value: number;
+    cells: Coord[];
+    mines: number;
+}
+
+export function solve(grid: CellView[][]): SolveResult {
+    const rows = grid.length;
+    const cols = rows > 0 ? grid[0].length : 0;
+
+    const status: number[][] = grid.map(row => row.map(() => UNKNOWN));
+    const reasons = new Map<number, string>();
+    const references = new Map<number, Coord[]>();
+
+    const key = (r: number, c: number): number => r * cols + c;
+
+    const record = (r: number, c: number, reason: string, refs: Coord[]): void => {
+        reasons.set(key(r, c), reason);
+        references.set(key(r, c), refs);
+    };
+
+    const neighbors = (r: number, c: number): Coord[] => {
+        const result: Coord[] = [];
+        for (let i = Math.max(r - 1, 0); i <= Math.min(r + 1, rows - 1); i++) {
+            for (let j = Math.max(c - 1, 0); j <= Math.min(c + 1, cols - 1); j++) {
+                if (i === r && j === c) continue;
+                result.push([i, j]);
+            }
+        }
+        return result;
+    };
+
+    const markSafe = (r: number, c: number, reason: string, refs: Coord[]): boolean => {
+        if (status[r][c] !== UNKNOWN) return false;
+        status[r][c] = SAFE;
+        record(r, c, reason, refs);
+        return true;
+    };
+
+    const markMine = (r: number, c: number, reason: string, refs: Coord[]): boolean => {
+        if (status[r][c] !== UNKNOWN) return false;
+        status[r][c] = MINE;
+        record(r, c, reason, refs);
+        return true;
+    };
+
+    // A constraint is a revealed number reduced to its hidden, unflagged
+    // neighbors, with flagged neighbors subtracted from the required count.
+    // Only *visible* facts go in — deductions are never folded back, so every
+    // constraint (and thus every explanation) is checkable on the board.
+    const buildConstraints = (): Constraint[] => {
+        const constraints: Constraint[] = [];
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) {
+                if (!grid[r][c].revealed) continue;
+                let mines = grid[r][c].value;
+                const cells: Coord[] = [];
+                for (const [nr, nc] of neighbors(r, c)) {
+                    if (grid[nr][nc].revealed) continue;
+                    if (grid[nr][nc].flagged) {
+                        mines--;
+                    } else {
+                        cells.push([nr, nc]);
+                    }
+                }
+                if (cells.length > 0) {
+                    constraints.push({ row: r, col: c, value: grid[r][c].value, cells, mines });
+                }
+            }
+        }
+        return constraints;
+    };
+
+    // A single pass over constraints built purely from the visible board. Each
+    // deduction below stands on its own — none relies on another, so there is
+    // no fixpoint iteration and no stale-snapshot hazard.
+    const constraints = buildConstraints();
+
+    // Single-number deduction.
+    for (const con of constraints) {
+        if (con.mines === 0) {
+            const reason = con.value === 0
+                ? "The highlighted 0 touches no mines at all, so this neighboring cell is safe."
+                : `The highlighted ${con.value} already has all of its mines flagged, so this bordering cell can't be a mine.`;
+            for (const [r, c] of con.cells) {
+                markSafe(r, c, reason, [[con.row, con.col]]);
+            }
+        } else if (con.mines === con.cells.length) {
+            const reason = con.cells.length === 1
+                ? `The highlighted ${con.value} still needs 1 mine and this is its only hidden neighbor left, so it must be a mine.`
+                : `The highlighted ${con.value} still needs ${con.mines} mines and has exactly ${con.cells.length} hidden neighbors left, so every one of them — including this cell — must be a mine.`;
+            for (const [r, c] of con.cells) {
+                markMine(r, c, reason, [[con.row, con.col]]);
+            }
+        }
+    }
+
+    // Overlap deduction. Iterating ordered pairs covers both directions, so
+    // this subsumes the plain subset case (when `a` has no unique cells).
+    // Every pair reasons from visible facts alone, so each firing is
+    // independently sound regardless of what other pairs concluded.
+    for (const a of constraints) {
+        for (const b of constraints) {
+            if (a === b) continue;
+
+            const aOnly = subtract(a.cells, b.cells, cols);
+            // The two numbers must actually share a cell to constrain each other.
+            if (aOnly.length === a.cells.length) continue;
+
+            // `a` needs exactly |aOnly| more mines than `b`, so those extra
+            // mines can only sit in `a`'s unique cells — pinning them as mines
+            // and forcing `b`'s unique cells safe.
+            const surplus = a.mines - b.mines;
+            if (surplus !== aOnly.length) continue;
+
+            const bOnly = subtract(b.cells, a.cells, cols);
+
+            // On hover the two referenced numbers are highlighted in distinct
+            // colors (reference 0 = orange, 1 = purple), named in the wording so
+            // the player can tell them apart. The explanations quote each number's
+            // *remaining* mines (a.mines / b.mines), which can be lower than the
+            // face value when some of its mines are flagged — quoting the face
+            // value here would read as a contradiction when both match.
+            // Keep the color words in sync with styles.css.
+            const refs: Coord[] = [[a.row, a.col], [b.row, b.col]];
+
+            let mineReason: string;
+            let safeReason: string;
+            if (b.mines === 0) {
+                // The purple number is fully satisfied, so "needs only 0" would
+                // sound absurd — say directly that its cells are all clear and
+                // the orange number's mines must avoid them.
+                const purple = b.value === 0
+                    ? "the purple 0 touches no mines at all"
+                    : `the purple ${b.value} already has ${b.value === 1 ? "its mine" : "all of its mines"} flagged`;
+                mineReason = aOnly.length === 1
+                    ? `While ${purple}, the orange ${a.value} still needs 1 mine — so it must be here, in the only cell the orange ${a.value} touches and the purple ${b.value} doesn't.`
+                    : `While ${purple}, the orange ${a.value} still needs ${a.mines} mines — and they can only be in the cells the orange ${a.value} touches and the purple ${b.value} doesn't, like this one.`;
+                safeReason = `Since ${purple}, every cell it touches — including this one — is safe.`;
+            } else {
+                const premise = `The orange ${a.value} still needs ${a.mines} ${plural(a.mines)} among the cells it touches while the purple ${b.value} needs only ${b.mines}, so the difference can only fall in the cells that just the orange ${a.value} touches`;
+                mineReason = `${premise} — and this is one of them.`;
+                safeReason = surplus === 0
+                    ? `Every cell the orange ${a.value} touches is also touched by the purple ${b.value}, and both still need the same number of mines — so the purple ${b.value}'s other cells, including this one, are safe.`
+                    : `${premise} — leaving this cell, touched only by the purple ${b.value}, safe.`;
+            }
+
+            for (const [r, c] of aOnly) {
+                markMine(r, c, mineReason, refs);
+            }
+            for (const [r, c] of bOnly) {
+                markSafe(r, c, safeReason, refs);
+            }
+        }
+    }
+
+    const safe: HintCell[] = [];
+    const mines: HintCell[] = [];
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (status[r][c] === UNKNOWN) continue;
+            const cell: HintCell = {
+                row: r,
+                col: c,
+                reason: reasons.get(key(r, c))!,
+                references: references.get(key(r, c))! as Array<[number, number]>,
+            };
+            (status[r][c] === SAFE ? safe : mines).push(cell);
+        }
+    }
+    return { safe, mines };
+}
+
+function subtract(b: Coord[], a: Coord[], cols: number): Coord[] {
+    const aKeys = new Set(a.map(([r, c]) => r * cols + c));
+    return b.filter(([r, c]) => !aKeys.has(r * cols + c));
+}
+
+function plural(n: number): string {
+    return n === 1 ? "mine" : "mines";
+}

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,6 +1,7 @@
 export class Timer {
     private intervaID: number | undefined;
     private value: number = 0;
+    private bumpTimeout: number | undefined;
 
     constructor(private el: HTMLElement) { }
 
@@ -25,6 +26,17 @@ export class Timer {
         this.value = 0;
         this.intervaID = undefined;
         this.updateEl();
+    }
+
+    public addTime(seconds: number): void {
+        this.value += seconds;
+        this.updateEl();
+
+        this.el.classList.add("bump");
+        if (this.bumpTimeout !== undefined) {
+            window.clearTimeout(this.bumpTimeout);
+        }
+        this.bumpTimeout = window.setTimeout(() => this.el.classList.remove("bump"), 1000);
     }
 
     private updateEl(): void {

--- a/src/util/pub-sub.ts
+++ b/src/util/pub-sub.ts
@@ -12,6 +12,7 @@ export const EVENT_GAME_OVER = "gameOver";
 export const EVENT_SAFE_AREA_CREATED = "safeAreaCreated";
 export const EVENT_SETTINGS_CHANGED = "settingsChanged";
 export const EVENT_MODE_CHANGED = "modeChanged";
+export const EVENT_HINT_MODE_CHANGED = "hintModeChanged";
 
 export class PubSub {
 

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,7 @@ main {
     --cell-background-repeat: no-repeat;
     --cell-background-position: center;
 
+    position: relative;
     display: table;
     background-color: #bdbdbd;
     border-style: solid;
@@ -62,7 +63,7 @@ main {
 
 #controls .buttons-wrapper {
     display: flex;
-    width: 120rem;
+    width: 165rem;
     justify-content: space-between;
 }
 
@@ -114,6 +115,10 @@ main {
     
 }
 
+#controls .buttons-wrapper .control#hint .icon {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PGcgZmlsbD0iIzAwMDAwMCI+PHBhdGggZD0iTTMyIDVjLTkuNCAwLTE3IDcuNi0xNyAxNyAwIDYuNSAzLjYgMTEgNi45IDE0LjIgMS45IDEuOSAzLjEgNCAzLjEgNi44djFoMTR2LTFjMC0yLjggMS4yLTQuOSAzLjEtNi44QzQ4LjQgMzMgNTIgMjguNSA1MiAyMmMwLTkuNC03LjYtMTctMTctMTd6Ii8+PHJlY3QgeD0iMjQiIHk9IjQ3IiB3aWR0aD0iMTYiIGhlaWdodD0iNSIgcng9IjIuNSIvPjxyZWN0IHg9IjI2IiB5PSI1NCIgd2lkdGg9IjEyIiBoZWlnaHQ9IjQiIHJ4PSIyIi8+PHJlY3QgeD0iMjkiIHk9IjU5IiB3aWR0aD0iNiIgaGVpZ2h0PSIzIiByeD0iMS41Ii8+PC9nPjwvc3ZnPg==);
+}
+
 #controls .buttons-wrapper .control#toggle-settings .icon {
     background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+IDxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+IC5zdDEze3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1taXRlcmxpbWl0OjEwO30gPC9zdHlsZT4gPGc+IDxwYXRoIGNsYXNzPSJzdDEzIiBkPSJNNjIuNCw0MC45bC05LjQtN2MwLjEtMS4yLDAuMS0yLjUsMC0zLjdsOS4xLTYuN2MwLjgtMC42LDEuMS0xLjYsMC43LTIuNWwtMS4zLTMuMmMtMC4zLTAuNi0wLjktMS0xLjYtMC45ICAgbC0xMS42LDEuN2MtMC44LTEtMS43LTEuOC0yLjctMi42bDEuNy0xMS4yYzAuMS0xLTAuNC0xLjktMS4zLTIuM2wtMy4yLTEuM2MtMC42LTAuMy0xLjQtMC4xLTEuOCwwLjVsLTcsOS40ICAgYy0xLjItMC4xLTIuNS0wLjEtMy43LDBMMjMuNCwyYy0wLjYtMC44LTEuNi0xLjEtMi41LTAuN2wtMy4yLDEuM2MtMC42LDAuMy0xLDAuOS0wLjksMS42bDEuNywxMS42Yy0xLDAuOC0xLjgsMS43LTIuNiwyLjcgICBMNC43LDE2LjhjLTEtMC4xLTEuOSwwLjQtMi4zLDEuM2wtMS4zLDMuMmMtMC4zLDAuNi0wLjEsMS40LDAuNSwxLjhsOS40LDdjLTAuMSwxLjItMC4xLDIuNSwwLDMuN0wyLDQwLjYgICBjLTAuOCwwLjYtMS4xLDEuNi0wLjcsMi41bDEuMywzLjJjMC4zLDAuNiwwLjksMSwxLjYsMC45bDExLjYtMS43YzAuOCwxLDEuNywxLjgsMi43LDIuNmwtMS43LDExLjJjLTAuMSwxLDAuNCwxLjksMS4zLDIuMyAgIGwzLjIsMS4zYzAuNiwwLjMsMS40LDAuMSwxLjgtMC41bDctOS40YzEuMiwwLjEsMi41LDAuMSwzLjcsMGw2LjcsOS4xYzAuNiwwLjgsMS42LDEuMSwyLjUsMC43bDMuMi0xLjNjMC42LTAuMywxLTAuOSwwLjktMS42ICAgbC0xLjctMTEuNmMxLTAuOCwxLjgtMS43LDIuNi0yLjdsMTEuMiwxLjdjMSwwLjEsMS45LTAuNCwyLjMtMS4zbDEuMy0zLjJDNjMuMiw0Miw2Mi45LDQxLjMsNjIuNCw0MC45eiBNMzIsNDQgICBjLTYuNiwwLTEyLTUuNC0xMi0xMmMwLTYuNiw1LjQtMTIsMTItMTJzMTIsNS40LDEyLDEyQzQ0LDM4LjYsMzguNiw0NCwzMiw0NHoiIC8+IDwvZz4gPC9zdmc+);
     
@@ -128,6 +133,16 @@ main {
     padding: 4rem 5rem;
     cursor: default;
     line-height: 25rem;
+}
+
+#controls #timer {
+    transition: color var(--transition-duration) var(--transition-function),
+        background-color var(--transition-duration) var(--transition-function);
+}
+
+#controls #timer.bump {
+    color: #000000;
+    background-color: #ff0000;
 }
 
 #board {
@@ -170,6 +185,35 @@ main {
     border-style: solid none none solid;
     border-width: 2rem;
     border-color: #7b7b7b;
+}
+
+.cell.hint {
+    cursor: help;
+    animation: hint-pulse 1s ease-in-out infinite;
+}
+
+@keyframes hint-pulse {
+    0%, 100% { background-color: #a6f0a6; }
+    50% { background-color: #4fc44f; }
+}
+
+.cell.hint.hint-danger {
+    animation: hint-danger-pulse 1s ease-in-out infinite;
+}
+
+@keyframes hint-danger-pulse {
+    0%, 100% { background-color: #ffb3b3; }
+    50% { background-color: #ff3b3b; }
+}
+
+.cell.hint-ref-a {
+    box-shadow: inset 0 0 0 4rem #ff8c00;
+    background-color: #ffd7a6;
+}
+
+.cell.hint-ref-b {
+    box-shadow: inset 0 0 0 4rem #9c27b0;
+    background-color: #e6bff0;
 }
 
 .cell.debug-mine {
@@ -339,6 +383,31 @@ main {
     color: #ff0000;
 }
 
+
+#hint-message {
+    position: absolute;
+    left: 50%;
+    bottom: 30rem;
+    transform: translateX(-50%);
+    max-width: calc(100% - 50rem);
+    box-sizing: border-box;
+    text-align: center;
+    background-color: #000000;
+    color: #ffffff;
+    font-family: monospace;
+    font-size: 16rem;
+    line-height: 22rem;
+    padding: 10rem 16rem;
+    border-radius: 4rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 200ms var(--transition-function);
+    z-index: 10;
+}
+
+#hint-message.show {
+    opacity: 0.95;
+}
 
 @media all and (display-mode: standalone) {
     html {

--- a/test/solver.test.mjs
+++ b/test/solver.test.mjs
@@ -1,0 +1,221 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { solve } from "../dist/solver/minesweeperSolver.js";
+
+const hidden = () => ({ revealed: false, flagged: false, value: 0 });
+const flag = () => ({ revealed: false, flagged: true, value: 0 });
+const num = (value) => ({ revealed: true, flagged: false, value });
+
+// Collects "row,col" strings so order-independent comparisons are easy.
+const coords = (result) => result.safe.map(({ row, col }) => `${row},${col}`).sort();
+
+test("an empty board yields no hints", () => {
+    const grid = [[hidden(), hidden()], [hidden(), hidden()]];
+    assert.deepEqual(solve(grid).safe, []);
+});
+
+test("a satisfied '0' clears all its hidden neighbors", () => {
+    // (0,0) is a revealed 0, so its three neighbors are provably safe.
+    const grid = [
+        [num(0), hidden()],
+        [hidden(), hidden()],
+    ];
+    assert.deepEqual(coords(solve(grid)), ["0,1", "1,0", "1,1"]);
+    // Every returned cell carries an explanation and references the '0' at (0,0).
+    for (const cell of solve(grid).safe) {
+        assert.ok(cell.reason.length > 0);
+        assert.deepEqual(cell.references, [[0, 0]]);
+    }
+});
+
+test("a '1' next to a single flag clears its other neighbors", () => {
+    // Row: [flag][1][hidden] — the 1's mine is the flag, so (0,2) is safe.
+    const grid = [[flag(), num(1), hidden()]];
+    assert.deepEqual(coords(solve(grid)), ["0,2"]);
+});
+
+test("a fully-forced '1' pins the mine and reports it separately from safe cells", () => {
+    // [1][hidden]: the 1 forces its only hidden neighbor to be a mine.
+    const grid = [[num(1), hidden()]];
+    const result = solve(grid);
+    assert.deepEqual(result.safe, []);
+    assert.deepEqual(coords({ safe: result.mines }), ["0,1"]);
+    // The mine explanation points back at the '1'.
+    assert.deepEqual(result.mines[0].references, [[0, 0]]);
+});
+
+test("subset (1-1-1) deduction clears cells no single number can", () => {
+    // Three 1s in a row over three hidden cells (a, b, c):
+    //   [1][1][1]
+    //   [a][b][c]
+    // The only consistent solution is b = mine, a and c safe. Proving a/c safe
+    // requires comparing two overlapping constraints, not a single number.
+    const grid = [
+        [num(1), num(1), num(1)],
+        [hidden(), hidden(), hidden()],
+    ];
+    assert.deepEqual(coords(solve(grid)), ["1,0", "1,2"]);
+    // b IS provably a mine, but only by building on a/c being safe — a chained
+    // deduction. Only first-level hints are reported, so it must stay out.
+    assert.deepEqual(solve(grid).mines, []);
+});
+
+test("a '3' beside a flag reduces to a '2' and overlaps a '1' to clear a cell", () => {
+    // Bottom row: [flag][3][1][hidden].  Top row: four hidden cells.
+    //   a b c d      <- (0,0)..(0,3)
+    //   M 3 1 e      <- (1,0)..(1,3)
+    // The flag reduces the 3 to "2 mines among {a,b,c}". The 1 covers {b,c,d,e}.
+    // 2 - 1 == |{a}| forces a to be a mine and d, e to be safe — a deduction no
+    // single number, nor a strict subset, can make on its own.
+    const grid = [
+        [hidden(), hidden(), hidden(), hidden()],
+        [flag(), num(3), num(1), hidden()],
+    ];
+    assert.deepEqual(coords(solve(grid)), ["0,3", "1,3"]);
+    // The explanation points at the two numbers involved: the 3 and the 1.
+    for (const cell of solve(grid).safe) {
+        assert.deepEqual(cell.references, [[1, 1], [1, 2]]);
+    }
+    // (0,0) is provably a mine — reported in mines, never in safe.
+    const result = solve(grid);
+    assert.ok(result.safe.every(({ row, col }) => !(row === 0 && col === 0)));
+    assert.ok(result.mines.some(({ row, col }) => row === 0 && col === 0));
+});
+
+test("hints never lean on other hints — explanations stand on visible numbers alone", () => {
+    // [0][1][1] over [a][b][x]: the solver used to chain here — the 0 proved a
+    // and b safe, which internally shrank the middle 1 until it pinned x with an
+    // explanation resting on those other hints. x is still found, but now via a
+    // single overlap of two visible numbers (the 1 and the 0), so the
+    // explanation is self-contained and both numbers highlight on hover.
+    const grid = [
+        [num(0), num(1), num(1)],
+        [hidden(), hidden(), hidden()],
+    ];
+    const result = solve(grid);
+    assert.deepEqual(coords(result), ["1,0", "1,1"]);
+    assert.deepEqual(result.mines.map(({ row, col }) => `${row},${col}`), ["1,2"]);
+
+    const mine = result.mines[0];
+    assert.deepEqual(mine.references, [[0, 1], [0, 0]]);
+    assert.ok(!mine.reason.includes("provably safe"),
+        `explanation should not lean on other deductions: "${mine.reason}"`);
+});
+
+test("flagged cells are never reported as safe moves", () => {
+    const grid = [[flag(), num(1), hidden()]];
+    assert.ok(solve(grid).safe.every(({ row, col }) => !(row === 0 && col === 0)));
+});
+
+// Deterministic PRNG so the sweep is reproducible.
+const makeRng = (seed) => {
+    let s = seed >>> 0;
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0;
+        return s / 4294967296;
+    };
+};
+
+// Builds a consistent mid-game 4x4 board: random mines, correct numbers, a
+// random subset of the safe cells revealed.
+const makeBoard = (rng) => {
+    const rows = 4, cols = 4;
+    const mine = Array.from({ length: rows }, () => Array(cols).fill(false));
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (rng() < 0.22) mine[r][c] = true;
+        }
+    }
+    const count = (r, c) => {
+        let n = 0;
+        for (let i = Math.max(r - 1, 0); i <= Math.min(r + 1, rows - 1); i++) {
+            for (let j = Math.max(c - 1, 0); j <= Math.min(c + 1, cols - 1); j++) {
+                if (!(i === r && j === c) && mine[i][j]) n++;
+            }
+        }
+        return n;
+    };
+    return Array.from({ length: rows }, (_, r) =>
+        Array.from({ length: cols }, (_, c) => {
+            const revealed = !mine[r][c] && rng() < 0.6;
+            return { revealed, flagged: false, value: revealed ? count(r, c) : 0 };
+        })
+    );
+};
+
+// Enumerates every mine assignment to the hidden cells that satisfies all the
+// revealed numbers, and returns the cells that are mine (or safe) in ALL of them.
+const bruteTruth = (grid) => {
+    const rows = grid.length, cols = grid[0].length;
+    const unknown = [];
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (!grid[r][c].revealed && !grid[r][c].flagged) unknown.push([r, c]);
+        }
+    }
+    const idx = new Map(unknown.map(([r, c], i) => [r * cols + c, i]));
+
+    const constraints = [];
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (!grid[r][c].revealed) continue;
+            const cells = [];
+            let fixed = 0;
+            for (let i = Math.max(r - 1, 0); i <= Math.min(r + 1, rows - 1); i++) {
+                for (let j = Math.max(c - 1, 0); j <= Math.min(c + 1, cols - 1); j++) {
+                    if (i === r && j === c) continue;
+                    if (grid[i][j].flagged) { fixed++; continue; }
+                    const k = idx.get(i * cols + j);
+                    if (k !== undefined) cells.push(k);
+                }
+            }
+            constraints.push({ cells, need: grid[r][c].value - fixed });
+        }
+    }
+
+    const n = unknown.length;
+    const alwaysMine = new Array(n).fill(true);
+    const alwaysSafe = new Array(n).fill(true);
+    let consistent = 0;
+    for (let mask = 0; mask < (1 << n); mask++) {
+        let ok = true;
+        for (const con of constraints) {
+            let m = 0;
+            for (const k of con.cells) if (mask & (1 << k)) m++;
+            if (m !== con.need) { ok = false; break; }
+        }
+        if (!ok) continue;
+        consistent++;
+        for (let k = 0; k < n; k++) {
+            if (mask & (1 << k)) alwaysSafe[k] = false; else alwaysMine[k] = false;
+        }
+    }
+
+    const trulySafe = new Set();
+    const trulyMine = new Set();
+    for (let k = 0; k < n; k++) {
+        const [r, c] = unknown[k];
+        if (alwaysSafe[k]) trulySafe.add(r * cols + c);
+        if (alwaysMine[k]) trulyMine.add(r * cols + c);
+    }
+    return { trulySafe, trulyMine, consistent };
+};
+
+test("solver never reports a cell that isn't provable (randomised soundness sweep)", () => {
+    const rng = makeRng(0xC0FFEE);
+    for (let t = 0; t < 400; t++) {
+        const grid = makeBoard(rng);
+        const cols = grid[0].length;
+        const { trulySafe, trulyMine, consistent } = bruteTruth(grid);
+        if (consistent === 0) continue; // unreachable: the true layout is consistent
+
+        const { safe, mines } = solve(grid);
+        for (const { row, col } of safe) {
+            assert.ok(trulySafe.has(row * cols + col), `board #${t}: (${row},${col}) reported safe but isn't provable`);
+        }
+        for (const { row, col } of mines) {
+            assert.ok(trulyMine.has(row * cols + col), `board #${t}: (${row},${col}) reported mine but isn't provable`);
+        }
+    }
+});


### PR DESCRIPTION
This PR implements the Hints functionality.

A new button is added at the top of the board that lets the players requests hints. A hint may show the player any provable safe cells or mines, according to the current game state. The use of hints costs the player some time (currently set to 10s). The type of hints (safe cells vs mines) can be switched through the settings.
After a hint is requested, in case there are provable moves, the corresponding cells are highlighted and an explanation is given on hover. If no provable move is available, a message is shown instead.
The README is updated accordingly.