### PR TITLE
Extracted configuration into JSON

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           # Each rule: <include-glob>|<content-type>|<cache-control>
           rules=(
             "index.html|text/html; charset=utf-8|no-cache"
+            "config.json|application/json; charset=utf-8|no-cache"
             "*.js|application/javascript; charset=utf-8|public, max-age=3600"
             "*.css|text/css; charset=utf-8|public, max-age=3600"
             "*.svg|image/svg+xml; charset=utf-8|public, max-age=3600"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,13 @@ subscribing over wiring direct method calls.
 
 Core flow:
 
-- **`main.ts`** — entry point. Builds the `Config` object (mode, encoder, pairer,
-  first-click rule, dark mode, debug flag) and instantiates `Game`. This is the one
-  place to swap which `Encoder` / `Pairer` implementation is used.
+- **`main.ts`** — entry point. `fetch`es the tunable settings (mode, first-click rule,
+  hint mode/cost, dark mode, debug flag) from `config.json` at the project root, merges
+  in the code-only fields (`encoder`, `modePairer`, `github`) to build the `Config`
+  object, and instantiates `Game`. This is the one place to swap which `Encoder` /
+  `Pairer` implementation is used, and where the `github` repo is set. `config.json` is
+  served over HTTP alongside the app (which is why local play needs a server, not
+  `file://`); the release workflow uploads it to S3 with a dedicated no-cache rule.
 - **`Game`** (`game.ts`) — orchestrator. Owns the UI controls (counter, timer, reset
   / replay / settings buttons), subscribes to game events, and drives `initialize()`
   which decides how a board is created: reset, replay, from a URL hash, or fresh from

--- a/README.md
+++ b/README.md
@@ -25,13 +25,23 @@ $ npx serve
 After that open the printed URL (e.g. http://localhost:3000) in your browser.
 
 ## Settings
-| Setting | Options | Default |
-| ------- | ------- | ------- |
-| mode | `beginner`, `intermediate`, `expert` | `expert` |
-| first click * | `guaranteed non-mine`, `guaranteed cascade` | `guaranteed cascade` |
-| hint shows | `mines`, `safe cells` | `mines` |
-| dark mode | `enabled`, `disabled` | `enabled` |
-| debug ** | `true`, `false` | `false` |
+The tunable settings are seeded from `config.json` at the project root, which is
+fetched when the game loads. Editing it and reloading changes the defaults with no
+recompile (the game must be served over HTTP — see [Requirements](#requirements)).
+`mode`, `first click`, `hint mode`, and `dark mode` are also adjustable at runtime
+through the in-game settings panel; `hint cost` and `debug` are configuration-only.
+
+Each row below maps an option to the `config.json` value it corresponds to
+(✓ marks the default):
+
+| Setting | Config key | Option | Config value | Default |
+| ------- | ---------- | ------ | ------------ | :-----: |
+| mode | `mode` | `beginner`<br>`intermediate`<br>`expert` | `"beginner"`<br>`"intermediate"`<br>`"expert"` | <br><br>✓ |
+| first click * | `firstClick` | `guaranteed non-mine`<br>`guaranteed cascade` | `0`<br>`1` | <br>✓ |
+| hint mode | `hintMode` | `mines`<br>`safe cells` | `"mines"`<br>`"safe"` | ✓<br>&nbsp; |
+| hint cost | `hintCost` | any whole number of seconds added to the timer per hint | `10` | `10` |
+| dark mode | `darkModeOn` | `enabled`<br>`disabled` | `true`<br>`false` | ✓<br>&nbsp; |
+| debug ** | `debug` | `false`<br>`true` | `false`<br>`true` | ✓<br>&nbsp; |
 
 _* considered only for new game_  
 _** will probably not become available to the user_

--- a/README.md
+++ b/README.md
@@ -31,20 +31,18 @@ recompile (the game must be served over HTTP — see [Requirements](#requirement
 `mode`, `first click`, `hint mode`, and `dark mode` are also adjustable at runtime
 through the in-game settings panel; `hint cost` and `debug` are configuration-only.
 
-Each row below maps an option to the `config.json` value it corresponds to
-(✓ marks the default):
 
 | Setting | Config key | Option | Config value | Default |
 | ------- | ---------- | ------ | ------------ | :-----: |
 | mode | `mode` | `beginner`<br>`intermediate`<br>`expert` | `"beginner"`<br>`"intermediate"`<br>`"expert"` | <br><br>✓ |
 | first click * | `firstClick` | `guaranteed non-mine`<br>`guaranteed cascade` | `0`<br>`1` | <br>✓ |
 | hint mode | `hintMode` | `mines`<br>`safe cells` | `"mines"`<br>`"safe"` | ✓<br>&nbsp; |
-| hint cost | `hintCost` | any whole number of seconds added to the timer per hint | `10` | `10` |
+| hint cost ** | `hintCost` | any whole number of seconds added to the timer per hint | `10` | `10` |
 | dark mode | `darkModeOn` | `enabled`<br>`disabled` | `true`<br>`false` | ✓<br>&nbsp; |
 | debug ** | `debug` | `false`<br>`true` | `false`<br>`true` | ✓<br>&nbsp; |
 
-_* considered only for new game_  
-_** will probably not become available to the user_
+_* considered only for a new game (e.g. ignored on replay or load from URL hash)_  
+_** in the configuration only, not available in the settings panel_
 
 ## Game modes
 | Mode | Rows | Columns | Mines |

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+    "mode": "expert",
+    "firstClick": 1,
+    "hintMode": "mines",
+    "hintCost": 10,
+    "debug": false,
+    "darkModeOn": true
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,10 @@ export interface Config {
     github: GitHub
 }
 
+/** The JSON-serializable settings loaded from `config.json`. The code-only fields
+ * (`encoder`, `modePairer`, `github`) are supplied in `main.ts`. */
+export type ConfigData = Omit<Config, "encoder" | "modePairer" | "github">;
+
 interface GitHub {
     owner: string;
     repo: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,20 @@
 import { Game } from "./game.js";
-import { FIRST_CLICK, HINT_MODE, MODE_NAME, Config } from "./config.js";
+import { Config, ConfigData } from "./config.js";
 import { CantorPairer } from "./pairer/cantorPairer.js";
 import { BinaryToBase64UrlEncoderV2 } from "./encoder/binaryToBase64UrlEncoderV2.js";
 
-const config: Config = {
-    mode: MODE_NAME.Expert,
-    encoder: BinaryToBase64UrlEncoderV2.prototype,
-    modePairer: CantorPairer.prototype,
-    firstClick: FIRST_CLICK.GuaranteedCascade,
-    hintMode: HINT_MODE.Mines,
-    hintCost: 10,
-    debug: false,
-    darkModeOn: true,
-    github: {
-        owner: "rdlf0",
-        repo: "minesweeper"
-    }
-}
+fetch("config.json")
+    .then((res) => res.json() as Promise<ConfigData>)
+    .then((data) => {
+        const config: Config = {
+            ...data,
+            encoder: BinaryToBase64UrlEncoderV2.prototype,
+            modePairer: CantorPairer.prototype,
+            github: {
+                owner: "rdlf0",
+                repo: "minesweeper",
+            },
+        };
 
-new Game(config); // nosonar
+        new Game(config); // nosonar
+    });


### PR DESCRIPTION
Since the project was transformed into using ES modules, it now has to be served even when running locally. This allows for the configuration to be loaded from its own dedicated JSON file. Doing so lets the user update it without having to recompile the typescript code. The config file itself is pretty small, so an initial fetch before loading the game shouldn't be a problem.

The `pairer` and `encoder` fields are left in TypeScript since they are implementations of specific classes. The `github` field also remains hardcoded since it doesn't make sense to be changed.

The README has been updated accordingly.