### PR TITLE
Adapted for mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,14 @@ share-a-board work. The encoding pipeline:
 
 Decoding reverses this. `extractMode` validates the result (min rows/cols,
 mines-to-cells ratio) and returns `null` on anything malformed, so callers must handle
-the fallback. `Pairer` and `Encoder` are interfaces with interchangeable
+the fallback. A hash may legitimately stop after the 24-bit mode and carry no layout —
+that asks for a fresh board of that size, and the PWA shortcuts in `manifest.webmanifest`
+are exactly this. `extractState` distinguishes the two: no layout bits at all is a `warn`,
+while layout bits that don't fill the board are an `error`. `Game.generateBoard` only
+reads a layout once `extractMode` has succeeded, so a hash with no valid mode can't
+produce a misleading "missing layout" message. Those shortcut hashes are hand-maintained
+and go stale when a preset changes — regenerate them with the current `Pairer`/`Encoder`
+rather than editing by hand. `Pairer` and `Encoder` are interfaces with interchangeable
 implementations selected in `main.ts`; the encoder/pairer chosen must stay consistent
 between encode and decode, so changing the default in `main.ts` invalidates
 previously shared URLs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,59 @@ implementations selected in `main.ts`; the encoder/pairer chosen must stay consi
 between encode and decode, so changing the default in `main.ts` invalidates
 previously shared URLs.
 
+### Mobile / touch (`util/device.ts`)
+
+Touch devices take a different path throughout. The single detector is
+`isTouchDevice()` — `matchMedia("(pointer: coarse)")`, so phones and tablets qualify but
+desktops and touchscreen laptops don't. It's deliberately the only place that decision
+is made; change it there and everything follows.
+
+- **Board size.** Instead of a `BOARD_CONFIG` preset, `Game.generateBoard` derives a
+  `Mode` from the screen via `computeDeviceMode(width, height, density)` — rows and cols
+  chosen so each cell lands near `TARGET_CELL_SIDE` (40px), and mines from
+  `mobileMineDensity` clamped to `[MIN_MINES_TO_CELLS_RATIO, MAX_MINES_TO_CELLS_RATIO]`
+  (in `config.ts`, shared with `urlTool`'s decode validation). That density seeds from
+  `config.json` and is then player-adjustable via the `Mine density` slider (see below).
+  `getDeviceBoardArea()` is orientation-independent (short
+  viewport side = board width), so rotation doesn't change the derived mode.
+  `computeDeviceMode` is pure and unit-tested in `test/deviceMode.test.mjs`.
+- **Layout.** One `@media (pointer: coarse)` block at the end of `styles.css` drops the
+  desktop `calc()` sizing and fixed margins/borders; `#board` becomes a `1fr` grid inside
+  a full-viewport flex column, so it fills the screen exactly. `#controls`' `56rem`
+  height must stay in step with `MOBILE_CONTROLS_HEIGHT`.
+- **Input.** `Cell` registers `contextmenu` only on non-touch; on touch it registers the
+  `TOUCH_EVENTS` set instead. One gesture scheme, not configurable: **a tap reveals, a
+  press-and-hold of `LONG_PRESS_MS` marks** (flag → question → default). The hold sets
+  `suppressClick` so the release can't reveal a cell the hold just cycled back to default
+  — that guard is load-bearing, not defensive. A drag past `LONG_PRESS_MOVE_TOLERANCE`
+  cancels the hold so swiping doesn't scatter flags. Reveal no-ops on a marked cell,
+  matching a desktop left click. `.cell` needs `touch-action: manipulation` (kills the tap
+  delay) and `-webkit-touch-callout: none` (stops iOS's callout on a hold).
+- **Haptics.** `vibrate()` in `util/device.ts` is called from exactly one place: a mine
+  going off. There is deliberately **no** buzz when flagging — Android fires its own
+  haptic on a press-and-hold, and adding ours produced a double buzz on real hardware
+  (verified on a Pixel 7 Pro and a OnePlus 13). Don't "fix" that omission. There is no
+  in-game haptics setting either; the phone's own silent mode and system touch-feedback
+  toggle already gate it, and `navigator.vibrate()` returns `true` even when the device
+  silently drops the buzz, so its return value can't be used to detect that.
+- **URL hash is ignored on touch.** A shared board carries fixed dimensions that wouldn't
+  fit, so `generateBoard` skips the hash branch and plays a device board — whose own hash
+  is then written, keeping mobile boards shareable outward. Replay is unaffected (it
+  reads `board.getState()` from memory).
+- **Portrait only.** A `(pointer: coarse) and (orientation: landscape)` rule hides `main`
+  and shows `#rotate-message`. `Game.lockPortraitOrientation()` additionally attempts
+  `screen.orientation.lock("portrait")`, which only succeeds in an installed mobile PWA
+  and rejects harmlessly elsewhere. The manifest stays `"orientation": "any"` so the
+  desktop PWA can still run in a landscape window.
+- **Settings differ by device.** The `Mode` fieldset is hidden on touch — dimensions come
+  from the screen, so the presets can't change anything. In its place touch gets
+  `Mine density`, a slider over `[MIN_MINES_TO_CELLS_RATIO, MAX_MINES_TO_CELLS_RATIO]`
+  that is hidden on desktop (density only shapes device-derived boards). The slider works
+  in whole percent so dragging can't accumulate float drift, and only commits on `change`,
+  not `input` — committing per input event would rebuild the board dozens of times in one
+  drag. Its readout shows the resulting mine count for this screen, computed with the same
+  `computeDeviceMode` the board uses, so the two can't disagree.
+
 ## Conventions
 
 - Keep it dependency-free and simple (the explicit contributing rule).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,35 @@ implementations selected in `main.ts`; the encoder/pairer chosen must stay consi
 between encode and decode, so changing the default in `main.ts` invalidates
 previously shared URLs.
 
+### Hints
+
+`Board.showHint` runs `solver/minesweeperSolver.ts` and marks the results, keeping them in
+`hints` (cell + `reason` + the cells the deduction rests on). The hint button then steps
+through them: the first press solves and charges `hintCost`, and each press after that
+calls `Board.focusHint(i)` to advance — same solve, so it is **not** charged again.
+`Game.allowHint` resets the cycle whenever the board changes.
+
+**How the explanation is delivered differs by device**, because the original design was
+hover-only and unusable on touch:
+
+- **Desktop** keeps the `title` tooltip `Cell.setHint` sets, plus the `mouseenter`
+  reference highlighting. `explainFocusedHint` returns early here — a toast big enough for
+  a solver sentence lands on the controls, and hover already works. Repeat presses of the
+  hint button therefore do nothing, as before the stepping existed.
+- **Touch** gets the `#hint-message` toast, prefixed `(n/total)` — without that counter
+  nothing tells the player more hints are waiting — and a `hint-focus` ring so it's clear
+  which cell the text describes. `focusHint` returns the hinted cell's row so `Game` can
+  flip the toast to whichever half the cell **isn't** in (`.at-top`, a touch-only class);
+  the board fills the screen here, so a fixed anchor would cover the cell being explained.
+
+The toast has **no timeout** — an explanation is read at the player's pace. It clears on
+dismiss, on stepping to another hint, on any board change, and on game over. That last one
+is easy to miss: detonating a mine returns early in `Cell.reveal` and never publishes
+`EVENT_CELL_REVEALED`, so `allowHint` never runs and `gameOver` has to retire the hint
+itself. It takes `pointer-events` only while `.show` is set — opaque to input on purpose,
+since letting taps through would fire whichever cell sits under the text, unseen — and a
+click anywhere on it dismisses, with `#hint-message-close` as the visible affordance.
+
 ### Mobile / touch (`util/device.ts`)
 
 Touch devices take a different path throughout. The single detector is

--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@ After that open the printed URL (e.g. http://localhost:3000) in your browser.
 The tunable settings are seeded from `config.json` at the project root, which is
 fetched when the game loads. Editing it and reloading changes the defaults with no
 recompile (the game must be served over HTTP — see [Requirements](#requirements)).
-`mode`, `first click`, `hint mode`, and `dark mode` are also adjustable at runtime
-through the in-game settings panel; `hint cost` and `debug` are configuration-only.
+`first click`, `hint mode`, and `dark mode` are also adjustable at runtime through the
+in-game settings panel; `hint cost` and `debug` are configuration-only. The remaining
+two are device-specific: `mode` is in the panel on desktop only, and `mine density` on
+touch devices only — see [Mobile / touch devices](#mobile--touch-devices).
 
 
-| Setting | Config key | Option | Config value | Default |
-| ------- | ---------- | ------ | ------------ | :-----: |
-| mode | `mode` | `beginner`<br>`intermediate`<br>`expert` | `"beginner"`<br>`"intermediate"`<br>`"expert"` | <br><br>✓ |
-| first click * | `firstClick` | `guaranteed non-mine`<br>`guaranteed cascade` | `0`<br>`1` | <br>✓ |
-| hint mode | `hintMode` | `mines`<br>`safe cells` | `"mines"`<br>`"safe"` | ✓<br>&nbsp; |
-| hint cost ** | `hintCost` | any whole number of seconds added to the timer per hint | `10` | `10` |
-| dark mode | `darkModeOn` | `enabled`<br>`disabled` | `true`<br>`false` | ✓<br>&nbsp; |
-| debug ** | `debug` | `false`<br>`true` | `false`<br>`true` | ✓<br>&nbsp; |
-
-_* considered only for a new game (e.g. ignored on replay or load from URL hash)_  
-_** in the configuration only, not available in the settings panel_
+| Setting | Config key | Option | Config value | Default | Notes |
+| ------- | ---------- | ------ | ------------ | :-----: | ----- |
+| mode | `mode` | `beginner`<br>`intermediate`<br>`expert` | `"beginner"`<br>`"intermediate"`<br>`"expert"` | <br><br>✓ | ignored on touch devices, where the board is derived from the screen |
+| first click | `firstClick` | `guaranteed non-mine`<br>`guaranteed cascade` | `0`<br>`1` | <br>✓ | considered only for a new game (e.g. ignored on replay or load from URL hash) |
+| hint mode | `hintMode` | `mines`<br>`safe cells` | `"mines"`<br>`"safe"` | ✓<br>&nbsp; | |
+| hint cost | `hintCost` | any whole number of seconds added to the timer per hint | `10` | `10` | in the configuration only, not available in the settings panel |
+| dark mode | `darkModeOn` | `enabled`<br>`disabled` | `true`<br>`false` | ✓<br>&nbsp; | |
+| mine density | `mobileMineDensity` | share of cells that are mines, between `0.05` and `0.25` | `0.18` | `0.18` | touch devices only; values outside the range are clamped to it |
+| debug | `debug` | `false`<br>`true` | `false`<br>`true` | ✓<br>&nbsp; | in the configuration only, not available in the settings panel |
 
 ## Game modes
 | Mode | Rows | Columns | Mines |
@@ -51,6 +51,9 @@ _** in the configuration only, not available in the settings panel_
 | `intermediate` | 16 | 16 | 40 |
 | `expert` | 16 | 30 | 99 |
 
+These presets apply on desktop. Touch devices size the board from the screen instead —
+see [Mobile / touch devices](#mobile--touch-devices).
+
 ## First click options
 | Option | Meaning |
 | ------ | ------- |
@@ -58,7 +61,7 @@ _** in the configuration only, not available in the settings panel_
 | `guaranteed cascade` | the first clicked cell has a value of 0 |
 
 ## Hint options
-The hint button (💡) runs a built-in logic solver over the current board and highlights every cell it can prove, each with an explanation shown on hover. It never guesses — only cells that logic guarantees are highlighted — and it reasons purely from what's on the board, so every explanation is checkable at a glance. Each hint costs the player some time (added to the timer); the cost is shown in the button's tooltip.
+The hint button (💡) runs a built-in logic solver over the current board and highlights every cell it can prove, each with an explanation shown on hover (on touch devices the explanation is delivered differently — see [Mobile / touch devices](#mobile--touch-devices)). It never guesses — only cells that logic guarantees are highlighted — and it reasons purely from what's on the board, so every explanation is checkable at a glance. Each hint costs the player some time (added to the timer); the cost is shown in the button's tooltip.
 
 | Option | Meaning |
 | ------ | ------- |
@@ -66,14 +69,64 @@ The hint button (💡) runs a built-in logic solver over the current board and h
 | `safe cells` | highlight the cells that are provably safe to reveal (pulsing green) |
 
 ## Game start options
-| Option | Mode | State *** |
-| ------ | ---- | ----- |
-| from a URL | from settings | random |
-| from a URL with a hash | from hash | from hash |
-| new game (reset) | from current board | random |
-| replay | from current board | from current board |
+| Option | Mode | State (the positioning of the mines) | Notes |
+| ------ | ---- | ----- | ----- |
+| from a URL | from settings | random | |
+| from a URL with a hash | from hash | from hash | on touch devices the hash is ignored — see [Mobile / touch devices](#mobile--touch-devices) |
+| new game (reset) | from current board | random | |
+| replay | from current board | from current board | |
 
-_*** The state represents the positioning of the mines_
+## Mobile / touch devices
+The game plays differently on phones and tablets. A device counts as touch when its
+primary pointer is coarse (`(pointer: coarse)`), so touchscreen laptops still get the
+desktop experience.
+
+### The board is derived from the screen
+There are no presets on touch. The board is sized to fill the screen with cells around
+40px a side — big enough to hit with a finger — so rows and columns come from the
+viewport rather than from `mode`. The number of mines is then that cell count times the
+mine density (`mobileMineDensity`, clamped to 5–25%).
+
+The sizing uses the short side of the viewport as the board width regardless of how the
+device is held, so rotating it doesn't change the board. Resizing the window (or
+installing the PWA, which changes the available height) recomputes the board and starts
+a new game — but only before the first move, and only if the resulting rows, columns or
+mines actually differ, so a game in progress is never thrown away.
+
+Because a board is sized for the screen it was created on, **a shared URL hash is
+ignored on touch** — the fixed dimensions it carries wouldn't fit. You get a board for
+your screen instead, and its own hash is written to the URL, so boards played on a
+phone can still be shared outwards. Replay is unaffected.
+
+The game is **portrait only**: in landscape the board is replaced by a prompt to rotate
+back. Installed as a PWA it also asks the system to lock the orientation.
+
+### Touch controls
+| Gesture | Action |
+| ------- | ------ |
+| tap | reveal a cell (no-op on a flagged or questioned cell, same as a desktop left click) |
+| press and hold (0.4s) | cycle the mark: flag → question mark → unmarked |
+
+Sliding your finger away during a hold cancels it, so scrolling or dragging across the
+board won't scatter flags. A hold that marks a cell won't also reveal it on release.
+The only haptic feedback is a buzz when a mine goes off; flagging is left to the
+device's own press-and-hold haptic. Both follow the phone's silent mode and system
+touch-feedback settings.
+
+### Hints
+The hint explanation can't be delivered by a hover tooltip on touch, so hints appear as
+a message at the top or bottom of the screen — whichever half the hinted cell isn't in
+— with the cell itself ringed. The message is numbered (e.g. `(2/5)`) when the solver
+found more than one hint; pressing 💡 again steps to the next one, which is free, since
+it's the same solve. It stays up until you dismiss it (tap it or its ×), step to
+another hint, or the board changes.
+
+### Settings
+The `Mode` fieldset is hidden — dimensions come from the screen, so the presets have
+nothing to change. In its place there's a `Mine density` slider covering 5–25%, hidden
+on desktop for the same reason in reverse. The slider reads out the resulting mine
+count for your screen rather than the percentage, and only rebuilds the board when you
+let go.
 
 ## Contributing
 Please check [CONTRIBUTING.md](CONTRIBUTING.md).  

--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
     "hintMode": "mines",
     "hintCost": 10,
     "debug": false,
-    "darkModeOn": true
+    "darkModeOn": true,
+    "mobileMineDensity": 0.18
 }

--- a/index.html
+++ b/index.html
@@ -45,7 +45,10 @@
         </div>
         <div id="board"></div>
         <div id="settings"></div>
-        <div id="hint-message"></div>
+        <div id="hint-message">
+            <span id="hint-message-text"></span>
+            <button id="hint-message-close" type="button" aria-label="Dismiss hint">&times;</button>
+        </div>
         <div id="win-message">🎉 You won! 🎉</div>
         <button id="test-win" type="button" style="display:none;position:fixed;top:10px;right:10px;z-index:100;">Test Win</button>
     </main>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,12 @@
         <div id="win-message">✨ You won! ✨</div>
         <button id="test-win" type="button" style="display:none;position:fixed;top:10px;right:10px;z-index:100;">Test Win</button>
     </main>
+    <!-- Sibling of <main>, which the landscape gate in styles.css hides. -->
+    <div id="rotate-message">
+        <div class="rotate-icon">📱</div>
+        <div>Minesweeper is played in portrait.</div>
+        <div>Please rotate your device.</div>
+    </div>
     <script type="text/javascript" src="pwa-resize.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
         <div id="board"></div>
         <div id="settings"></div>
         <div id="hint-message"></div>
-        <div id="win-message">✨ You won! ✨</div>
+        <div id="win-message">🎉 You won! 🎉</div>
         <button id="test-win" type="button" style="display:none;position:fixed;top:10px;right:10px;z-index:100;">Test Win</button>
     </main>
     <!-- Sibling of <main>, which the landscape gate in styles.css hides. -->

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -7,7 +7,7 @@
     "lang": "en-US",
     "dir": "ltr",
     "display": "standalone",
-    "orientation": "landscape",
+    "orientation": "any",
     "id": "/",
     "start_url": "/",
     "categories": [

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -61,7 +61,7 @@
         {
             "name": "Beginner mode",
             "description": "Beginner mode",
-            "url": "/#AEbr",
+            "url": "/#ALBo",
             "icons": [
                 {
                     "src": "/assets/icons/favicon_96.svg",

--- a/pwa-resize.js
+++ b/pwa-resize.js
@@ -1,5 +1,6 @@
 (function () {
-    if (matchMedia("(display-mode: standalone)").matches) {
+    // Desktop only — resizeTo is a no-op on mobile, where the board fills the screen.
+    if (matchMedia("(display-mode: standalone)").matches && !matchMedia("(pointer: coarse)").matches) {
         let width;
         let height;
         const widthPadding = 53;

--- a/src/board.ts
+++ b/src/board.ts
@@ -29,6 +29,13 @@ export class Board {
 
     private hintHovers: { cell: Cell; enter: () => void; leave: () => void; refs: { cell: Cell; kind: string }[] }[] = [];
 
+    /** The hints from the last solve, in the order the hint button steps through them.
+     * Carries the explanation so it can be surfaced without a hover. */
+    private hints: { cell: Cell; reason: string; refs: { cell: Cell; kind: string }[] }[] = [];
+
+    /** Index into `hints` currently being explained, or -1 when none is. */
+    private focusedHint: number = -1;
+
     // Whether the currently shown hints are mines (cleared on flag) rather than
     // safe cells (cleared on reveal).
     private hintDanger: boolean = false;
@@ -284,14 +291,52 @@ export class Board {
                 kind: i === 0 ? "a" : "b",
             }));
             const enter = () => refs.forEach(({ cell, kind }) => cell.addReference(kind));
-            const leave = () => refs.forEach(({ cell }) => cell.clearReference());
+            const leave = () => {
+                refs.forEach(({ cell }) => cell.clearReference());
+                // Hovering away shouldn't strip the references of the focused hint.
+                this.applyFocusReferences();
+            };
             const el = cell.getElement();
             el.addEventListener("mouseenter", enter);
             el.addEventListener("mouseleave", leave);
             this.hintHovers.push({ cell, enter, leave, refs });
+            this.hints.push({ cell, reason, refs });
         }
 
         return cells.length;
+    }
+
+    public getHintCount(): number {
+        return this.hints.length;
+    }
+
+    /** Marks one hint as the one being explained, lights the cells its deduction rests on,
+     * and returns its explanation plus the row it sits on, so the caller can keep its
+     * message from covering it. Wraps, so the caller can just keep incrementing. */
+    public focusHint(index: number): { reason: string; row: number } | null {
+        if (this.hints.length === 0) {
+            return null;
+        }
+
+        this.hints.forEach(hint => {
+            hint.cell.setHintFocus(false);
+            hint.refs.forEach(ref => ref.cell.clearReference());
+        });
+
+        this.focusedHint = index % this.hints.length;
+        const hint = this.hints[this.focusedHint];
+        hint.cell.setHintFocus(true);
+        this.applyFocusReferences();
+
+        return { reason: hint.reason, row: hint.cell.getRow() };
+    }
+
+    private applyFocusReferences(): void {
+        if (this.focusedHint < 0 || this.focusedHint >= this.hints.length) {
+            return;
+        }
+
+        this.hints[this.focusedHint].refs.forEach(({ cell, kind }) => cell.addReference(kind));
     }
 
     private clearHintsOnReveal(): void {
@@ -307,6 +352,8 @@ export class Board {
     public clearHints(): void {
         this.hintedCells.forEach(cell => cell.clearHint());
         this.hintedCells = [];
+        this.hints = [];
+        this.focusedHint = -1;
 
         this.hintHovers.forEach(({ cell, enter, leave, refs }) => {
             const el = cell.getElement();

--- a/src/board.ts
+++ b/src/board.ts
@@ -254,10 +254,7 @@ export class Board {
     public deactivateCells(): void {
         for (let i = 0; i < this.mode.rows; i++) {
             for (let j = 0; j < this.mode.cols; j++) {
-                const cell = this.grid[i][j];
-                cell.getElement().removeEventListener("click", cell);
-                cell.getElement().removeEventListener("contextmenu", cell);
-                cell.getElement().addEventListener("contextmenu", e => e.preventDefault());
+                this.grid[i][j].deactivate();
             }
         }
     }

--- a/src/cell.ts
+++ b/src/cell.ts
@@ -7,6 +7,19 @@ import {
     PubSub,
 } from "./util/pub-sub.js";
 import { Session } from "./util/session.js";
+import {
+    isTouchDevice,
+    vibrate,
+    LONG_PRESS_MS,
+    LONG_PRESS_MOVE_TOLERANCE,
+} from "./util/device.js";
+
+/** Double buzz when a mine goes off. Flagging gets no buzz from us — Android already
+ * fires its own haptic on a press-and-hold. */
+const HAPTIC_EXPLOSION = [80, 40, 160];
+
+/** The listeners a cell needs on touch: a tap reveals, a press-and-hold flags. */
+const TOUCH_EVENTS = ["click", "pointerdown", "pointermove", "pointerup", "pointercancel"];
 
 enum CellState {
     Default = "default",
@@ -26,6 +39,10 @@ export class Cell {
     private value: number;
     private el: HTMLElement;
     private state: CellState;
+    private longPressTimeout: number | undefined;
+    private pressX: number = 0;
+    private pressY: number = 0;
+    private suppressClick: boolean = false;
 
     constructor(
         private row: number,
@@ -44,8 +61,13 @@ export class Cell {
     private createHTMLElement(): void {
         this.el = document.createElement("div");
         this.el.classList.add("cell");
-        this.el.addEventListener("click", this);
-        this.el.addEventListener("contextmenu", this);
+
+        if (isTouchDevice()) {
+            TOUCH_EVENTS.forEach(type => this.el.addEventListener(type, this));
+        } else {
+            this.el.addEventListener("click", this);
+            this.el.addEventListener("contextmenu", this);
+        }
     }
 
     public getRow(): number {
@@ -136,6 +158,7 @@ export class Cell {
 
     private explode(): void {
         this.setState(CellState.Exploded);
+        vibrate(HAPTIC_EXPLOSION);
         PubSub.publish(EVENT_GAME_OVER);
     }
 
@@ -180,12 +203,78 @@ export class Cell {
     public handleEvent(e: Event) {
         switch (e.type) {
             case "click":
+                if (!isTouchDevice()) {
+                    this.reveal();
+                    break;
+                }
+
+                // A press-and-hold already acted on this cell; swallow its trailing click.
+                if (this.suppressClick) {
+                    this.suppressClick = false;
+                    break;
+                }
+
                 this.reveal();
+                break;
+            case "pointerdown":
+                this.startLongPress(e as PointerEvent);
+                break;
+            case "pointermove":
+                this.cancelLongPressIfDragged(e as PointerEvent);
+                break;
+            case "pointerup":
+            case "pointercancel":
+                this.cancelLongPress();
                 break;
             case "contextmenu":
                 e.preventDefault();
                 this.mark();
                 break;
         }
+    }
+
+    /** Arms the press-and-hold that flags. */
+    private startLongPress(e: PointerEvent): void {
+        this.suppressClick = false;
+        this.pressX = e.clientX;
+        this.pressY = e.clientY;
+
+        this.longPressTimeout = window.setTimeout(() => {
+            this.longPressTimeout = undefined;
+            // Deliberately no vibrate() here — Android fires its own haptic on a
+            // press-and-hold, and ours on top of it lands as a double buzz.
+            this.mark();
+            // Otherwise the release would reveal a cell the hold just cycled back to default.
+            this.suppressClick = true;
+        }, LONG_PRESS_MS);
+    }
+
+    /** A finger that travels is swiping, not holding. Touch pointers are implicitly
+     * captured, so these moves keep arriving here even once it leaves the cell. */
+    private cancelLongPressIfDragged(e: PointerEvent): void {
+        if (this.longPressTimeout === undefined) {
+            return;
+        }
+
+        if (Math.abs(e.clientX - this.pressX) > LONG_PRESS_MOVE_TOLERANCE ||
+            Math.abs(e.clientY - this.pressY) > LONG_PRESS_MOVE_TOLERANCE) {
+            this.cancelLongPress();
+        }
+    }
+
+    private cancelLongPress(): void {
+        if (this.longPressTimeout !== undefined) {
+            window.clearTimeout(this.longPressTimeout);
+            this.longPressTimeout = undefined;
+        }
+    }
+
+    /** Stops the cell responding to input once the game is over. */
+    public deactivate(): void {
+        this.cancelLongPress();
+
+        TOUCH_EVENTS.forEach(type => this.el.removeEventListener(type, this));
+        this.el.removeEventListener("contextmenu", this);
+        this.el.addEventListener("contextmenu", e => e.preventDefault());
     }
 }

--- a/src/cell.ts
+++ b/src/cell.ts
@@ -125,8 +125,13 @@ export class Cell {
         this.el.setAttribute("title", reason);
     }
 
+    /** Marks this hint as the one currently being explained. */
+    public setHintFocus(focused: boolean): void {
+        this.el.classList.toggle("hint-focus", focused);
+    }
+
     public clearHint(): void {
-        this.el.classList.remove("hint", "hint-danger");
+        this.el.classList.remove("hint", "hint-danger", "hint-focus");
         this.el.removeAttribute("title");
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ export interface Config {
     hintCost: number;
     debug: boolean;
     darkModeOn: boolean;
+    /** Mine-to-cell ratio for boards derived from the device screen (touch devices).
+     * Clamped to [MIN_MINES_TO_CELLS_RATIO, MAX_MINES_TO_CELLS_RATIO]. */
+    mobileMineDensity: number;
     github: GitHub
 }
 
@@ -46,6 +49,13 @@ export interface Mode {
     cols: number;
     mines: number;
 }
+
+/** Bounds every mode must satisfy — enforced when decoding a shared board in
+ * `urlTool.ts` and when deriving a board from the device screen in `util/device.ts`. */
+export const MIN_ROWS = 5;
+export const MIN_COLS = 5;
+export const MIN_MINES_TO_CELLS_RATIO = 0.05;
+export const MAX_MINES_TO_CELLS_RATIO = 0.25;
 
 type BoardConfig = {
     readonly [name in MODE_NAME]?: Mode;

--- a/src/game.ts
+++ b/src/game.ts
@@ -289,12 +289,18 @@ export class Game {
         } else if (!isTouchDevice() && this.urlTool.isHashSet()) {
             // Touch devices skip this branch: a shared board carries fixed dimensions
             // that would not fit the screen, so they always play a device-derived one.
-            mode = this.urlTool.extractMode() ?? this.board?.getMode() ?? BOARD_CONFIG[this.config.mode];
+            const decodedMode = this.urlTool.extractMode();
+            mode = decodedMode ?? this.board?.getMode() ?? BOARD_CONFIG[this.config.mode];
             this.config.mode = this.getModeNameFromMode(mode);
-            state = this.urlTool.extractState(mode);
 
-            if (state == null) {
-                console.warn("Could not extract mode or state from hash. Falling back to defaults.");
+            if (decodedMode == null) {
+                // Nothing usable in the hash at all — extractMode has already said why.
+                console.warn("Could not read a board from the hash. Falling back to defaults.");
+                state = null;
+            } else {
+                // Only worth reading a layout once we know which board it belongs to.
+                // extractState reports a missing layout itself, at the right severity.
+                state = this.urlTool.extractState(mode);
             }
         } else {
             mode = isTouchDevice() ? this.getDeviceMode() : BOARD_CONFIG[this.config.mode]!;

--- a/src/game.ts
+++ b/src/game.ts
@@ -17,6 +17,10 @@ import {
 } from "./util/pub-sub.js";
 import { Session } from "./util/session.js";
 import { Settings } from "./settings.js";
+import { isTouchDevice, getDeviceBoardArea, computeDeviceMode } from "./util/device.js";
+
+/** Debounce for the resize-driven recomputation of the device mode. */
+const RESIZE_DEBOUNCE_MS = 150;
 
 export class Game {
 
@@ -45,6 +49,7 @@ export class Game {
     private isReplay: boolean;
     private urlTool: UrlTool;
     private settingsOpened: boolean = false;
+    private resizeTimeout: number | undefined;
 
     constructor(private config: Config) {
         document.body.classList.toggle("dark", this.config.darkModeOn);
@@ -76,6 +81,10 @@ export class Game {
         this.hintMessageEl = document.getElementById("hint-message")!;
         this.winMessageEl = document.getElementById("win-message")!;
         window.addEventListener("hashchange", this.handleHashChange.bind(this));
+        // orientationchange fires a resize too, so this covers rotation as well.
+        window.addEventListener("resize", this.handleResize.bind(this));
+
+        this.lockPortraitOrientation();
 
         this.urlTool = new UrlTool(
             this.config.encoder,
@@ -178,6 +187,56 @@ export class Game {
         PubSub.publish(EVENT_MODE_CHANGED);
     }
 
+    /** An installed mobile PWA can genuinely hold portrait. Everywhere else this is
+     * unsupported and rejects harmlessly — the landscape message in `styles.css` is
+     * what actually guarantees portrait-only play. */
+    private lockPortraitOrientation(): void {
+        if (!isTouchDevice()) {
+            return;
+        }
+
+        const orientation = screen.orientation as ScreenOrientation & {
+            lock?: (orientation: string) => Promise<void>;
+        };
+
+        orientation?.lock?.("portrait").catch(() => { /* not supported here */ });
+    }
+
+    /** The device mode is derived from the viewport, so it has to be recomputed when
+     * the viewport changes — but never mid-game, or an in-progress board would be
+     * thrown away. */
+    private handleResize(): void {
+        if (!isTouchDevice() || Session.get("gameStarted") === true) {
+            return;
+        }
+
+        if (this.resizeTimeout !== undefined) {
+            clearTimeout(this.resizeTimeout);
+        }
+
+        this.resizeTimeout = window.setTimeout(() => {
+            this.resizeTimeout = undefined;
+
+            const mode = this.getDeviceMode();
+            const current = this.board.getMode();
+
+            if (mode.rows === current.rows &&
+                mode.cols === current.cols &&
+                mode.mines === current.mines) {
+                return;
+            }
+
+            this.logDebugMessage('======= DEVICE MODE CHANGED =======');
+            this.initialize(false, false);
+        }, RESIZE_DEBOUNCE_MS);
+    }
+
+    private getDeviceMode(): Mode {
+        const area = getDeviceBoardArea();
+
+        return computeDeviceMode(area.width, area.height, this.config.mobileMineDensity);
+    }
+
     private handleSettingsChange() {
         this.logDebugMessage('======= SETTINGS CHANGED =======');
 
@@ -227,7 +286,9 @@ export class Game {
             // Same as if started by a URL with a hash, but here we avoid decoding and unpairing
             mode = this.board.getMode();
             state = this.board.getState();
-        } else if (this.urlTool.isHashSet()) {
+        } else if (!isTouchDevice() && this.urlTool.isHashSet()) {
+            // Touch devices skip this branch: a shared board carries fixed dimensions
+            // that would not fit the screen, so they always play a device-derived one.
             mode = this.urlTool.extractMode() ?? this.board?.getMode() ?? BOARD_CONFIG[this.config.mode];
             this.config.mode = this.getModeNameFromMode(mode);
             state = this.urlTool.extractState(mode);
@@ -236,7 +297,7 @@ export class Game {
                 console.warn("Could not extract mode or state from hash. Falling back to defaults.");
             }
         } else {
-            mode = BOARD_CONFIG[this.config.mode]!;
+            mode = isTouchDevice() ? this.getDeviceMode() : BOARD_CONFIG[this.config.mode]!;
             state = null;
             Session.set("applyFirstClickRule", true);
         }

--- a/src/game.ts
+++ b/src/game.ts
@@ -22,6 +22,7 @@ import { isTouchDevice, getDeviceBoardArea, computeDeviceMode } from "./util/dev
 /** Debounce for the resize-driven recomputation of the device mode. */
 const RESIZE_DEBOUNCE_MS = 150;
 
+
 export class Game {
 
     // Visual elements
@@ -35,12 +36,14 @@ export class Game {
     private boardEl: HTMLElement;
     private settingsEl: HTMLElement;
     private hintMessageEl: HTMLElement;
+    private hintMessageTextEl: HTMLElement;
     private winMessageEl: HTMLElement;
     private winMessageTimeout: number | undefined;
-    private hintMessageTimeout: number | undefined;
     // Blocks re-invoking the hint until the player makes a move.
     private hintUsed: boolean = false;
     private lastHintMessage: string | undefined;
+    // Which of the current hints the button is explaining; advances on each press.
+    private hintIndex: number = 0;
 
     // Other properties
     private flagsCounter: number;
@@ -79,6 +82,10 @@ export class Game {
         this.boardEl = document.getElementById("board")!;
         this.settingsEl = document.getElementById("settings")!;
         this.hintMessageEl = document.getElementById("hint-message")!;
+        this.hintMessageTextEl = document.getElementById("hint-message-text")!;
+        // On the whole toast, not just the ×: it blocks input anyway, so a tap anywhere
+        // on it should dismiss rather than do nothing. The × clicks bubble up here too.
+        this.hintMessageEl.addEventListener("click", this.hideHintMessage.bind(this));
         this.winMessageEl = document.getElementById("win-message")!;
         window.addEventListener("hashchange", this.handleHashChange.bind(this));
         // orientationchange fires a resize too, so this covers rotation as well.
@@ -136,7 +143,12 @@ export class Game {
         }
 
         if (this.hintUsed) {
-            if (this.lastHintMessage !== undefined) {
+            // The board hasn't changed, so there's nothing new to solve. Step to the next
+            // explanation instead — same hint, so it isn't charged again.
+            if (this.board.getHintCount() > 0) {
+                this.hintIndex++;
+                this.explainFocusedHint();
+            } else if (this.lastHintMessage !== undefined) {
                 this.flashHintMessage(this.lastHintMessage);
             }
             return;
@@ -147,6 +159,7 @@ export class Game {
         // Using the helper costs the player time, even when it finds nothing.
         this.timer.addTime(this.config.hintCost);
         this.hintUsed = true;
+        this.hintIndex = 0;
 
         if (found === 0) {
             this.lastHintMessage = this.config.hintMode === HINT_MODE.Mines
@@ -155,24 +168,58 @@ export class Game {
             this.flashHintMessage(this.lastHintMessage);
         } else {
             this.lastHintMessage = undefined;
+            this.explainFocusedHint();
         }
+    }
+
+    /** Surfaces the current hint's explanation somewhere reachable without a mouse, and
+     * lights the cells its deduction rests on.
+     *
+     * Touch only. On desktop the `title` tooltip already delivers the explanation on
+     * hover, and a toast large enough to hold one can cover the controls. */
+    private explainFocusedHint(): void {
+        if (!isTouchDevice()) {
+            return;
+        }
+
+        const count = this.board.getHintCount();
+        const focus = this.board.focusHint(this.hintIndex);
+
+        if (focus === null) {
+            return;
+        }
+
+        // On mobile the board fills the screen, so a fixed message always covers cells.
+        // Put it in the half the hinted cell isn't in, or it hides what it's describing.
+        const inTopHalf = focus.row < this.board.getMode().rows / 2;
+        this.hintMessageEl.classList.toggle("at-top", !inTopHalf);
+
+        // Without the counter there's nothing telling the player more hints are waiting.
+        const position = count > 1 ? `(${(this.hintIndex % count) + 1}/${count}) ` : "";
+        this.flashHintMessage(position + focus.reason);
+        this.hintMessageEl.classList.toggle("at-top", !inTopHalf);
     }
 
     private allowHint(): void {
         this.hintUsed = false;
         this.lastHintMessage = undefined;
+        this.hintIndex = 0;
+        // The board moved on, so whatever the message was explaining is stale.
+        this.hideHintMessage();
     }
 
+    /** Shows a message and leaves it up. A solver explanation is something to read, and no
+     * timeout suits every reader — it clears when the player dismisses it, steps to
+     * another hint, or changes the board. */
     private flashHintMessage(message: string): void {
-        this.hintMessageEl.textContent = message;
+        // Callers that have a cell to avoid re-anchor after this; the rest sit at the bottom.
+        this.hintMessageEl.classList.remove("at-top");
+        this.hintMessageTextEl.textContent = message;
         this.hintMessageEl.classList.add("show");
+    }
 
-        if (this.hintMessageTimeout !== undefined) {
-            clearTimeout(this.hintMessageTimeout);
-        }
-        this.hintMessageTimeout = window.setTimeout(() => {
-            this.hintMessageEl.classList.remove("show");
-        }, 3000);
+    private hideHintMessage(): void {
+        this.hintMessageEl.classList.remove("show");
     }
 
     private handleHashChange(): void {
@@ -254,6 +301,8 @@ export class Game {
         this.isOver = false;
         this.hintUsed = false;
         this.lastHintMessage = undefined;
+        this.hintIndex = 0;
+        this.hideHintMessage();
         this.timer.stop();
         this.timer.reset();
         this.boardEl.classList.remove("won");
@@ -371,6 +420,12 @@ export class Game {
         this.timer.stop();
         this.isOver = true;
         this.board.deactivateCells();
+
+        // Hitting a mine never publishes EVENT_CELL_REVEALED, so allowHint doesn't run
+        // here — the hint and its explanation have to be retired explicitly.
+        this.board.clearHints();
+        this.hideHintMessage();
+
         this.board.revealMines(win);
 
         if (win) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,12 +1,28 @@
-import { BOARD_CONFIG, Config, FIRST_CLICK, HINT_MODE, Mode, MODE_NAME } from "./config.js";
+import {
+    BOARD_CONFIG,
+    Config,
+    FIRST_CLICK,
+    HINT_MODE,
+    Mode,
+    MODE_NAME,
+    MIN_MINES_TO_CELLS_RATIO,
+    MAX_MINES_TO_CELLS_RATIO,
+} from "./config.js";
 import { EVENT_HINT_MODE_CHANGED, EVENT_MODE_CHANGED, EVENT_SETTINGS_CHANGED, PubSub } from "./util/pub-sub.js";
+import { isTouchDevice, getDeviceBoardArea, computeDeviceMode } from "./util/device.js";
 
 enum AVAILABLE_SETTINGS {
     mode = "Mode",
+    mineDensity = "Mine density",
     firstClick = "First click",
     hintMode = "Hint shows",
     darkMode = "Dark mode",
     about = "About",
+}
+
+/** The slider works in whole percent so dragging can't accumulate float drift. */
+function toPercent(ratio: number): number {
+    return Math.round(ratio * 100);
 }
 
 export class Settings {
@@ -24,6 +40,18 @@ export class Settings {
     private draw() {
         Object.keys(AVAILABLE_SETTINGS).forEach(settingKey => {
             const key = settingKey as keyof typeof AVAILABLE_SETTINGS;
+
+            // On touch devices the board is derived from the screen and its mine
+            // density comes from config, so the preset picker can't change anything.
+            if (key === "mode" && isTouchDevice()) {
+                return;
+            }
+
+            // Density only shapes device-derived boards, which desktop never builds.
+            if (key === "mineDensity" && !isTouchDevice()) {
+                return;
+            }
+
             const fieldset = document.createElement("fieldset");
             this.el.appendChild(fieldset)
 
@@ -38,6 +66,7 @@ export class Settings {
         settingFieldset.querySelectorAll(":not(legend)").forEach(e => e.remove());
         switch (setting) {
             case "mode": this.drawMode(settingFieldset); break;
+            case "mineDensity": this.drawMineDensity(settingFieldset); break;
             case "firstClick": this.drawFirstClick(settingFieldset); break;
             case "hintMode": this.drawHintMode(settingFieldset); break;
             case "darkMode": this.drawDarkMode(settingFieldset); break;
@@ -63,6 +92,43 @@ export class Settings {
         fieldset.append(modeDetailsWrapper);
         Object.keys(BOARD_CONFIG[MODE_NAME.Beginner]!).forEach(modeProperty => {
             this.drawModeDetails(modeDetailsWrapper, modeProperty);
+        });
+    }
+
+    private drawMineDensity(fieldset: HTMLElement) {
+        const wrapper = document.createElement("div");
+        wrapper.id = "density_wrapper";
+        fieldset.appendChild(wrapper);
+
+        const readout = document.createElement("label");
+        readout.setAttribute("for", "densitySlider");
+        wrapper.appendChild(readout);
+
+        const slider = document.createElement("input");
+        slider.setAttribute("type", "range");
+        slider.setAttribute("id", "densitySlider");
+        slider.min = toPercent(MIN_MINES_TO_CELLS_RATIO).toString();
+        slider.max = toPercent(MAX_MINES_TO_CELLS_RATIO).toString();
+        slider.step = "1";
+        slider.value = toPercent(this.config.mobileMineDensity).toString();
+        wrapper.appendChild(slider);
+
+        // The ratio behind the slider is an implementation detail; the mine count it
+        // produces on this screen is the thing a player can actually reason about.
+        const describe = () => {
+            const area = getDeviceBoardArea();
+            const mode = computeDeviceMode(area.width, area.height, Number(slider.value) / 100);
+            readout.textContent = `${mode.mines} mines`;
+        };
+
+        describe();
+
+        // Dragging only moves the readout. Rebuilding the board on every input event
+        // would regenerate it dozens of times per drag, so that waits for the release.
+        slider.addEventListener("input", describe);
+        slider.addEventListener("change", () => {
+            this.config.mobileMineDensity = Number(slider.value) / 100;
+            PubSub.publish(EVENT_SETTINGS_CHANGED);
         });
     }
 

--- a/src/urlTool.ts
+++ b/src/urlTool.ts
@@ -22,7 +22,9 @@ export class UrlTool {
         try {
             this.decodedHash = this.encoder.decode(window.location.hash.slice(1));
         } catch (e) {
-            console.error("Invalid hash!", e);
+            // Log the message, not the Error — its stack only points into the encoder
+            // and says nothing the message doesn't.
+            console.error(`Invalid hash! ${e instanceof Error ? e.message : String(e)}`);
             return null;
         }
 
@@ -33,7 +35,7 @@ export class UrlTool {
         const mines = decoded.b;
 
         if (mines < 1) {
-            console.error("Invalid hash! Can't extract mode!");
+            console.error(`Invalid hash! Decoded a board with no mines (${mines}).`);
             return null;
         }
 
@@ -42,10 +44,13 @@ export class UrlTool {
         const rows = decoded.a;
         const cols = decoded.b;
 
-        if (rows < MIN_ROWS ||
-            cols < MIN_COLS ||
-            (mines > rows * cols * MAX_MINES_TO_CELLS_RATIO)) {
-            console.error("Invalid hash! Can't extract mode!");
+        if (rows < MIN_ROWS || cols < MIN_COLS) {
+            console.error(`Invalid hash! Decoded board ${cols}x${rows} is below the ${MIN_COLS}x${MIN_ROWS} minimum.`);
+            return null;
+        }
+
+        if (mines > rows * cols * MAX_MINES_TO_CELLS_RATIO) {
+            console.error(`Invalid hash! Decoded board ${cols}x${rows} packs ${mines} mines, over the ${MAX_MINES_TO_CELLS_RATIO} limit.`);
             return null;
         }
 
@@ -57,8 +62,18 @@ export class UrlTool {
     }
 
     public extractState(mode: Mode): State | null {
-        const stateString = this.decodedHash.slice(MODE_SIZE, mode.rows * mode.cols + MODE_SIZE);
-        if (mode.rows * mode.cols != stateString.length) {
+        const expectedLength = mode.rows * mode.cols;
+        const stateString = this.decodedHash.slice(MODE_SIZE, expectedLength + MODE_SIZE);
+
+        // A hash that stops after the mode is well-formed — it just asks for a fresh
+        // board of that size. The PWA shortcuts in manifest.webmanifest are exactly this.
+        if (stateString.length === 0) {
+            console.warn("Hash carries a mode but no mine layout. Planting a new board.");
+            return null;
+        }
+
+        // Some layout bits are present but they don't fill the board: truncated or corrupt.
+        if (stateString.length !== expectedLength) {
             console.error("Invalid hash! Can't extract state!");
             return null;
         }

--- a/src/urlTool.ts
+++ b/src/urlTool.ts
@@ -1,12 +1,9 @@
 import { Encoder } from "./encoder/encoder.js";
 import { Pairer, Tuple } from "./pairer/pairer.js";
-import { Mode } from "./config.js";
+import { Mode, MIN_ROWS, MIN_COLS, MAX_MINES_TO_CELLS_RATIO } from "./config.js";
 import { State } from "./state.js";
 
 const MODE_SIZE = 24;
-const MIN_ROWS = 5;
-const MIN_COLS = 5;
-const MAX_MINES_TO_CELLS_RATIO = 0.25;
 
 export class UrlTool {
 

--- a/src/util/device.ts
+++ b/src/util/device.ts
@@ -1,0 +1,68 @@
+import {
+    Mode,
+    MIN_ROWS,
+    MIN_COLS,
+    MIN_MINES_TO_CELLS_RATIO,
+    MAX_MINES_TO_CELLS_RATIO,
+} from "../config.js";
+
+/** Cell size a finger can comfortably hit, in CSS pixels. */
+export const TARGET_CELL_SIDE = 40;
+
+/** Height of the controls bar on touch devices. Must match the `#controls` height
+ * in the `@media (pointer: coarse)` block of `styles.css`. */
+export const MOBILE_CONTROLS_HEIGHT = 56;
+
+/** How long a press must be held before it flags. */
+export const LONG_PRESS_MS = 400;
+
+/** A press that drifts further than this (in px) is a drag, not a hold. */
+export const LONG_PRESS_MOVE_TOLERANCE = 10;
+
+/** Buzzes the device. A no-op wherever the Vibration API is absent (iOS Safari, most
+ * desktops), and silently dropped by Android when the phone is on silent or has system
+ * touch feedback turned off — which is the only control players need over it. */
+export function vibrate(pattern: number | number[]): void {
+    navigator.vibrate?.(pattern);
+}
+
+/** Touch-primary devices — phones and tablets. Desktops and touchscreen laptops
+ * report a fine primary pointer and are treated as regular desktops. */
+export function isTouchDevice(): boolean {
+    return window.matchMedia("(pointer: coarse)").matches;
+}
+
+/** The area the board gets on a touch device, in CSS pixels.
+ *
+ * Orientation-independent on purpose: the game is portrait-only, so the short
+ * viewport side is always the board width. That keeps the derived mode stable when
+ * the device is rotated. */
+export function getDeviceBoardArea(): { width: number; height: number } {
+    const shortSide = Math.min(window.innerWidth, window.innerHeight);
+    const longSide = Math.max(window.innerWidth, window.innerHeight);
+
+    return {
+        width: shortSide,
+        height: longSide - MOBILE_CONTROLS_HEIGHT,
+    };
+}
+
+/** Derives a board that fills the given area with cells close to TARGET_CELL_SIDE.
+ *
+ * Rounding (rather than flooring) picks the cell count closest to the target; the
+ * mobile grid uses `1fr` tracks, so the board then fills the area exactly. */
+export function computeDeviceMode(width: number, height: number, density: number): Mode {
+    const cols = Math.max(MIN_COLS, Math.round(width / TARGET_CELL_SIDE));
+    const rows = Math.max(MIN_ROWS, Math.round(height / TARGET_CELL_SIDE));
+
+    const cells = rows * cols;
+    const clampedDensity = Math.min(
+        MAX_MINES_TO_CELLS_RATIO,
+        Math.max(MIN_MINES_TO_CELLS_RATIO, density),
+    );
+
+    // Floor, so the result always passes urlTool's `mines <= cells * MAX_RATIO` check.
+    const mines = Math.max(1, Math.floor(cells * clampedDensity));
+
+    return { rows, cols, mines };
+}

--- a/styles.css
+++ b/styles.css
@@ -217,6 +217,13 @@ main {
     50% { background-color: #ff3b3b; }
 }
 
+/* The hint the message is currently explaining. Drawn inside the box so neighbouring
+   grid cells can't clip it, and neutral so it reads over both pulse colours. */
+.cell.hint-focus {
+    outline: 3rem solid #000000;
+    outline-offset: -3rem;
+}
+
 .cell.hint-ref-a {
     box-shadow: inset 0 0 0 4rem #ff8c00;
     background-color: #ffd7a6;
@@ -480,6 +487,9 @@ main {
     max-width: calc(100% - 50rem);
     box-sizing: border-box;
     text-align: center;
+    display: flex;
+    align-items: flex-start;
+    gap: 4rem;
     background-color: #000000;
     color: #ffffff;
     font-family: monospace;
@@ -488,13 +498,50 @@ main {
     padding: 10rem 16rem;
     border-radius: 4rem;
     opacity: 0;
+    /* Only while visible: a faded-out toast is still in the layout and would otherwise
+       swallow taps on the board. */
     pointer-events: none;
     transition: opacity 200ms var(--transition-function);
     z-index: 10;
 }
 
+/* Deliberately opaque to input. Letting taps through would fire whichever cell happens
+   to sit under the text, which the player can't see — a blind reveal loses the game. */
 #hint-message.show {
     opacity: 0.95;
+    pointer-events: auto;
+    cursor: pointer;
+}
+
+#hint-message #hint-message-text {
+    flex: 1 1 auto;
+}
+
+/* Purely the affordance — the click handler sits on the toast, so anywhere dismisses. */
+#hint-message #hint-message-close {
+    flex: 0 0 auto;
+    appearance: none;
+    -webkit-appearance: none;
+    background: none;
+    border: none;
+    color: #ffffff;
+    font-family: inherit;
+    font-size: 22rem;
+    line-height: 22rem;
+    padding: 0 2rem;
+    margin: -2rem 0 0;
+    cursor: pointer;
+    /* Comfortable to hit with a thumb without inflating the toast. */
+    min-width: 28rem;
+    min-height: 28rem;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+}
+
+@media (hover: hover) {
+    #hint-message #hint-message-close:hover {
+        color: #ff8c00;
+    }
 }
 
 #board.won::after {
@@ -630,6 +677,22 @@ main {
 
     #settings {
         overflow-y: auto;
+    }
+
+    /* Flipped above the board when the hint being explained sits in its lower half.
+       Touch only — `.at-top` is never set on desktop, where a toast up here would land
+       on the controls. Must clear the controls bar. */
+    #hint-message.at-top {
+        top: calc(56rem + 12rem);
+        bottom: auto;
+    }
+
+    /* Wider and tighter than on desktop: fewer wrapped lines means fewer covered cells. */
+    #hint-message {
+        max-width: calc(100% - 16rem);
+        font-size: 15rem;
+        line-height: 20rem;
+        padding: 8rem 12rem;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -83,8 +83,10 @@ main {
     transition: background-color 200ms;
 }
 
-#controls .buttons-wrapper .control:hover {
-    background-color: #eeeeee;
+@media (hover: hover) {
+    #controls .buttons-wrapper .control:hover {
+        background-color: #eeeeee;
+    }
 }
 
 #controls .buttons-wrapper .control .icon {
@@ -97,9 +99,11 @@ main {
     transition: transform 200ms;
 }
 
-#controls .buttons-wrapper .control:hover .icon {
-    -webkit-transform: rotate(90deg);
-    transform: rotate(90deg);
+@media (hover: hover) {
+    #controls .buttons-wrapper .control:hover .icon {
+        -webkit-transform: rotate(90deg);
+        transform: rotate(90deg);
+    }
 }
 
 #controls .buttons-wrapper .control#reset .icon {
@@ -163,6 +167,10 @@ main {
     cursor: default;
     width: var(--cell-side);
     height: var(--cell-side);
+    /* Removes the browser's ~300ms tap delay and its double-tap-to-zoom, which would
+       otherwise swallow the second tap of the touch reveal gesture. */
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
     background-size: var(--cell-background-size);
     background-repeat: var(--cell-background-repeat);
     background-position: var(--cell-background-position);
@@ -174,6 +182,8 @@ main {
     -webkit-user-select: none;
     -ms-user-select: none;
     user-select: none;
+    /* Stops iOS Safari popping its callout menu on a press-and-hold. */
+    -webkit-touch-callout: none;
     align-items: center;
     justify-content: center;
 }
@@ -323,8 +333,10 @@ main {
     box-sizing: border-box;
 }
 
-#settings fieldset #mode_switch_wrapper div:hover {
-    background-color: #eeeeee;
+@media (hover: hover) {
+    #settings fieldset #mode_switch_wrapper div:hover {
+        background-color: #eeeeee;
+    }
 }
 
 #settings fieldset #mode_switch_wrapper div.active {
@@ -355,6 +367,79 @@ main {
     background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nNDA5JyBoZWlnaHQ9JzMzNycgdmVyc2lvbj0nMS4xJyB2aWV3Qm94PScwIDAgNDA5IDMzNycgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cmVjdCB4PSc3JyB5PScxOTMnIHdpZHRoPSc4MycgaGVpZ2h0PScxMzYnIHN0cm9rZT0nd2hpdGUnIGZpbGw9J2JsYWNrJyBzdHJva2Utd2lkdGg9JzE1JyByeD0nMScgcnk9JzEnIC8+PHJlY3QgeD0nMTU5JyB5PScxMTMnIHdpZHRoPSc4MycgaGVpZ2h0PScyMTYnIHN0cm9rZT0nd2hpdGUnIGZpbGw9J2JsYWNrJyBzdHJva2Utd2lkdGg9JzE1JyByeD0nMScgcnk9JzEnIC8+PHJlY3QgeD0nMzE4JyB5PSc3JyB3aWR0aD0nODMnIGhlaWdodD0nMzIyJyBzdHJva2U9J3doaXRlJyBmaWxsPSdibGFjaycgc3Ryb2tlLXdpZHRoPScxNScgcng9JzEnIHJ5PScxJyAvPjwvc3ZnPg==);
 }
 
+#settings fieldset #density_wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 4rem 14rem 10rem;
+}
+
+#settings fieldset #density_wrapper label {
+    /* Keeps the readout from jittering as the digits change mid-drag. */
+    font-variant-numeric: tabular-nums;
+    margin-bottom: 8rem;
+}
+
+#settings fieldset #density_wrapper input[type=range] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    margin: 0;
+    background: transparent;
+    /* Tall enough to grab with a finger, even though the track is thin. */
+    height: 30rem;
+}
+
+/* The track and thumb need one rule per engine — a selector list containing a
+   pseudo-element the browser doesn't know is dropped whole. */
+#settings fieldset #density_wrapper input[type=range]::-webkit-slider-runnable-track {
+    height: 10rem;
+    background-color: #bdbdbd;
+    border-style: solid;
+    border-width: 2rem;
+    border-color: #7b7b7b #ffffff #ffffff #7b7b7b;
+    box-sizing: border-box;
+}
+
+#settings fieldset #density_wrapper input[type=range]::-moz-range-track {
+    height: 10rem;
+    background-color: #bdbdbd;
+    border-style: solid;
+    border-width: 2rem;
+    border-color: #7b7b7b #ffffff #ffffff #7b7b7b;
+    box-sizing: border-box;
+}
+
+#settings fieldset #density_wrapper input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18rem;
+    height: 26rem;
+    /* Centres the thumb on the track: (track 10 - thumb 26) / 2. */
+    margin-top: -8rem;
+    background-color: #cccccc;
+    border-style: solid;
+    border-width: 2rem;
+    border-color: #ffffff #7b7b7b #7b7b7b #ffffff;
+    box-sizing: border-box;
+}
+
+#settings fieldset #density_wrapper input[type=range]::-moz-range-thumb {
+    width: 18rem;
+    height: 26rem;
+    border-radius: 0;
+    background-color: #cccccc;
+    border-style: solid;
+    border-width: 2rem;
+    border-color: #ffffff #7b7b7b #7b7b7b #ffffff;
+    box-sizing: border-box;
+}
+
+#settings fieldset #density_wrapper input[type=range]:focus-visible {
+    outline: 2rem solid #000000;
+    outline-offset: 2rem;
+}
+
 #settings fieldset #mode_details_wrapper {
     display: flex;
     justify-content: center;
@@ -380,8 +465,10 @@ main {
     transition-timing-function: var(--transition-function);
 }
 
-#settings fieldset a:hover {
-    color: #ff0000;
+@media (hover: hover) {
+    #settings fieldset a:hover {
+        color: #ff0000;
+    }
 }
 
 
@@ -480,5 +567,102 @@ main {
 
     main {
         margin: auto;
+    }
+}
+
+/* ---------------------------------------------------------------------------
+   Touch devices. The board is derived from the screen (see util/device.ts) and
+   fills the viewport edge to edge, so all the fixed widths, margins and borders
+   that frame the desktop board are dropped here.
+   Must come last so it wins over the standalone block above.
+   --------------------------------------------------------------------------- */
+@media (pointer: coarse) {
+    main {
+        width: 100vw;
+        height: 100vh;
+        height: 100dvh; /* accounts for the collapsing browser UI; ignored if unsupported */
+        margin: 0;
+        border: none;
+        display: flex;
+        flex-direction: column;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    /* Height must stay in step with MOBILE_CONTROLS_HEIGHT in src/util/device.ts. */
+    #controls {
+        flex: 0 0 auto;
+        height: 56rem;
+        margin: 0;
+        border-width: 0 0 5rem 0;
+        box-sizing: border-box;
+    }
+
+    #controls .buttons-wrapper {
+        width: 200rem;
+    }
+
+    #controls .buttons-wrapper .control {
+        width: 36rem;
+        height: 36rem;
+    }
+
+    /* Overrides the desktop calc() sizing — the grid gets whatever is left over. */
+    #board, #settings {
+        width: auto;
+        height: auto;
+        margin: 0;
+        border: none;
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+
+    #board {
+        grid-template-columns: repeat(var(--cols), 1fr);
+        grid-template-rows: repeat(var(--rows), 1fr);
+    }
+
+    /* 1fr tracks size the cells, so the grid fills the area exactly. */
+    .cell {
+        width: auto;
+        height: auto;
+    }
+
+    #settings {
+        overflow-y: auto;
+    }
+}
+
+#rotate-message {
+    display: none;
+}
+
+/* The game is portrait-only, Wordle-style. */
+@media (pointer: coarse) and (orientation: landscape) {
+    main {
+        display: none;
+    }
+
+    #rotate-message {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12rem;
+        padding: 24rem;
+        box-sizing: border-box;
+        background-color: #1e1e1e;
+        color: #ffffff;
+        font-family: monospace;
+        font-size: 18rem;
+        line-height: 26rem;
+        z-index: 30;
+    }
+
+    #rotate-message .rotate-icon {
+        font-size: 56rem;
+        line-height: 56rem;
     }
 }

--- a/test/deviceMode.test.mjs
+++ b/test/deviceMode.test.mjs
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeDeviceMode, TARGET_CELL_SIDE } from "../dist/util/device.js";
+import {
+    MIN_ROWS,
+    MIN_COLS,
+    MIN_MINES_TO_CELLS_RATIO,
+    MAX_MINES_TO_CELLS_RATIO,
+} from "../dist/config.js";
+import { CantorPairer } from "../dist/pairer/cantorPairer.js";
+
+// The mode is packed into a fixed 24-bit prefix of the hash (MODE_SIZE in urlTool.ts),
+// so any derived board must pair below this or the shared URL silently corrupts.
+const MODE_MAX = 2 ** 24 - 1;
+
+// Mirrors UrlTool.encodeMode: pair(pair(rows, cols), mines).
+function pairMode(mode) {
+    const pairer = new CantorPairer();
+    const rowsCols = pairer.pair({ a: mode.rows, b: mode.cols });
+
+    return pairer.pair({ a: rowsCols, b: mode.mines });
+}
+
+test("cells land close to the target touch size on a phone viewport", () => {
+    // iPhone 14 portrait, minus the controls bar.
+    const mode = computeDeviceMode(390, 788, 0.18);
+
+    assert.equal(mode.cols, 10); // 390 / 40 = 9.75 -> 10
+    assert.equal(mode.rows, 20); // 788 / 40 = 19.7 -> 20
+
+    // Every cell stays within a few px of the target once the 1fr tracks stretch.
+    assert.ok(Math.abs(390 / mode.cols - TARGET_CELL_SIDE) < 5);
+    assert.ok(Math.abs(788 / mode.rows - TARGET_CELL_SIDE) < 5);
+});
+
+test("a tiny viewport is still clamped to a playable board", () => {
+    const mode = computeDeviceMode(100, 120, 0.18);
+
+    assert.ok(mode.rows >= MIN_ROWS);
+    assert.ok(mode.cols >= MIN_COLS);
+    assert.ok(mode.mines >= 1);
+});
+
+test("density is clamped to the ratio bounds", () => {
+    const cells = 10 * 20;
+
+    const tooDense = computeDeviceMode(390, 788, 0.9);
+    assert.ok(tooDense.mines <= cells * MAX_MINES_TO_CELLS_RATIO);
+    assert.equal(tooDense.mines, Math.floor(cells * MAX_MINES_TO_CELLS_RATIO));
+
+    const tooSparse = computeDeviceMode(390, 788, 0);
+    assert.equal(tooSparse.mines, Math.floor(cells * MIN_MINES_TO_CELLS_RATIO));
+});
+
+test("derived boards always pass the hash validation in urlTool", () => {
+    // Phone through to a large tablet, across the full density range.
+    const viewports = [[320, 480], [390, 788], [414, 840], [768, 1000], [1024, 1310]];
+    const densities = [0, 0.05, 0.18, 0.25, 0.9];
+
+    for (const [width, height] of viewports) {
+        for (const density of densities) {
+            const mode = computeDeviceMode(width, height, density);
+
+            assert.ok(mode.rows >= MIN_ROWS, `rows for ${width}x${height}`);
+            assert.ok(mode.cols >= MIN_COLS, `cols for ${width}x${height}`);
+            assert.ok(mode.mines >= 1, `mines for ${width}x${height}`);
+            assert.ok(
+                mode.mines <= mode.rows * mode.cols * MAX_MINES_TO_CELLS_RATIO,
+                `mine ratio for ${width}x${height} @ ${density}`,
+            );
+            assert.ok(
+                pairMode(mode) <= MODE_MAX,
+                `mode pairs within 24 bits for ${width}x${height} @ ${density}`,
+            );
+        }
+    }
+});


### PR DESCRIPTION
Minesweeper is now more mobile-friendly! 🎉 
This PR adapts the game for mobile devices (e.g. `pointer: coarse`). The board size is not based on a preset, but on the display size with cells big enough to be hit with a finger. Mines count is between 5% and 25% (default is 18%) and can be adjusted through the `mobileMineDensity` setting, which is available only on mobile devices.
Gestures: touch for reveal and press-and-hold for marking.
Hints can be revolved though repeated tapping of the Hint button.
For more details see the updated README.