### PR TITLE
New game and Replay effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ back. Installed as a PWA it also asks the system to lock the orientation.
 | Gesture | Action |
 | ------- | ------ |
 | tap | reveal a cell (no-op on a flagged or questioned cell, same as a desktop left click) |
-| press and hold (0.4s) | cycle the mark: flag → question mark → unmarked |
+| press and hold (0.25s) | cycle the mark: flag → question mark → unmarked |
 
 Sliding your finger away during a hold cancels it, so scrolling or dragging across the
 board won't scatter flags. A hold that marks a cell won't also reveal it on release.

--- a/src/game.ts
+++ b/src/game.ts
@@ -119,6 +119,7 @@ export class Game {
         if (this.settingsOpened) {
             this.closeSettings();
         }
+        this.pulseButton(this.resetBtn);
         this.updateUrlHash(true);
         this.initialize(true, false);
     }
@@ -129,7 +130,21 @@ export class Game {
         if (this.settingsOpened) {
             this.closeSettings();
         }
+        this.pulseButton(this.replayBtn);
         this.initialize(false, true);
+    }
+
+    /** Acknowledges the press on the button itself. Touch only — desktop already answers
+     * with the hover background and icon rotation, and with no animation to end there the
+     * listener below would never fire and would pile up a click at a time.
+     * The class comes off on animationend: left on, it would override that hover transform. */
+    private pulseButton(btn: HTMLElement): void {
+        if (!isTouchDevice()) {
+            return;
+        }
+
+        this.restartAnimation(btn, "pressed");
+        btn.addEventListener("animationend", () => btn.classList.remove("pressed"), { once: true });
     }
 
     private showHint(): void {
@@ -306,6 +321,7 @@ export class Game {
         this.timer.stop();
         this.timer.reset();
         this.boardEl.classList.remove("won");
+        this.clearBoardEffect();
         this.winMessageEl.classList.remove("show");
         if (this.winMessageTimeout !== undefined) {
             clearTimeout(this.winMessageTimeout);
@@ -321,6 +337,20 @@ export class Game {
         this.board.draw();
 
         this.setFlags(0);
+
+        this.playBoardChangeEffect();
+    }
+
+    /** A rebuilt board is indistinguishable from the one it replaced — every cell is
+     * unrevealed either way — so New game and Replay have to announce themselves. Only
+     * those two: a hash or settings change is already visible on its own. */
+    private playBoardChangeEffect(): void {
+        if (!this.isReset && !this.isReplay) {
+            return;
+        }
+
+        this.boardEl.addEventListener("animationend", this.clearBoardEffect);
+        this.restartAnimation(this.boardEl, this.isReset ? "new-game" : "replayed");
     }
 
     private generateBoard(): void {
@@ -444,6 +474,14 @@ export class Game {
             this.winMessageEl.classList.remove("show");
         }, 4000);
     }
+
+    /** Retires a finished board effect. Leaving the class on would replay it: showing the
+     * board again — `closeSettings` flipping it back to `display: grid` — restarts every
+     * animation still attached to it. Kept as one instance so re-adding it is a no-op. */
+    private clearBoardEffect = (): void => {
+        this.boardEl.classList.remove("new-game", "replayed");
+        this.boardEl.removeEventListener("animationend", this.clearBoardEffect);
+    };
 
     // Re-adds a class so its CSS animation replays even if it was already applied.
     private restartAnimation(el: HTMLElement, className: string): void {

--- a/src/util/device.ts
+++ b/src/util/device.ts
@@ -14,7 +14,7 @@ export const TARGET_CELL_SIDE = 40;
 export const MOBILE_CONTROLS_HEIGHT = 56;
 
 /** How long a press must be held before it flags. */
-export const LONG_PRESS_MS = 400;
+export const LONG_PRESS_MS = 250;
 
 /** A press that drifts further than this (in px) is a drag, not a hold. */
 export const LONG_PRESS_MOVE_TOLERANCE = 10;

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,23 @@ main {
     
 }
 
+/* Touch only — applied by Game.pulseButton, which has no hover state to rely on. */
+#controls .buttons-wrapper .control#reset.pressed .icon {
+    animation: icon-spin-cw 400ms ease-out;
+}
+
+#controls .buttons-wrapper .control#replay.pressed .icon {
+    animation: icon-spin-ccw 400ms ease-out;
+}
+
+@keyframes icon-spin-cw {
+    to { transform: rotate(360deg); }
+}
+
+@keyframes icon-spin-ccw {
+    to { transform: rotate(-360deg); }
+}
+
 #controls #mines-counter, #controls #timer {
     background-color: #000000;
     color: #ff0000;
@@ -155,6 +172,8 @@ main {
     position: relative;
     display: grid;
     grid-template-columns: repeat(var(--cols), 1fr);
+    /* Clips the new-game sweep, which travels past both edges. */
+    overflow: hidden;
 }
 
 #board, #settings {
@@ -544,6 +563,51 @@ main {
     }
 }
 
+/* New game / replay feedback. On ::before — the win glow below owns ::after. */
+#board::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 5;
+    opacity: 0;
+}
+
+#board.new-game::before {
+    background: linear-gradient(115deg,
+        transparent 42%, rgba(255, 255, 255, 0.85) 50%, transparent 58%);
+    animation: board-new-game 550ms ease-out;
+}
+
+@keyframes board-new-game {
+    0%   { opacity: 0; transform: translateX(-120%); }
+    15%  { opacity: 1; }
+    85%  { opacity: 1; }
+    100% { opacity: 0; transform: translateX(120%); }
+}
+
+#board.replayed {
+    animation: board-replay 420ms ease-out;
+}
+
+@keyframes board-replay {
+    0%   { transform: scale(1); }
+    35%  { transform: scale(0.94); }
+    70%  { transform: scale(1.02); }
+    100% { transform: scale(1); }
+}
+
+#board.replayed::before {
+    background-color: rgba(255, 255, 255, 0.9);
+    animation: board-replay-flash 420ms ease-out;
+}
+
+@keyframes board-replay-flash {
+    0%   { opacity: 0; }
+    35%  { opacity: 0.35; }
+    100% { opacity: 0; }
+}
+
 #board.won::after {
     content: "";
     position: absolute;
@@ -592,6 +656,17 @@ main {
 
 @media (prefers-reduced-motion: reduce) {
     #board.won::after {
+        animation: none;
+    }
+
+    #board.new-game::before,
+    #board.replayed::before,
+    #board.replayed {
+        animation: none;
+    }
+
+    #controls .buttons-wrapper .control#reset.pressed .icon,
+    #controls .buttons-wrapper .control#replay.pressed .icon {
         animation: none;
     }
 


### PR DESCRIPTION
This PR adds some minor visual effects to the New game and Replay actions, so that they are more visible. Previously only the URL hash was changing, which made it hard for players to notice if they actually hit the button or not.

Also, a minor refinement to the mobile/touch experience - the press-and-hold threshold for flagging was reduced to 250ms (previously it was 400ms).